### PR TITLE
feat: sync modules via project API

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -1,13 +1,14 @@
 name: Sync modules.json from Issues
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'  # cada 30 minutos
+    - cron: '*/30 * * * *'
 
 permissions:
-  contents: write   # para commitear modules.json
+  contents: write
   issues: read
+  projects: read
 
 jobs:
   sync:
@@ -15,34 +16,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22.x'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            **/go.sum
 
       - name: Build sync tool
         run: |
-          go mod tidy
+          set -euo pipefail
+          go mod tidy || true
           go build -o sync-modules ./cmd/sync-modules
 
       - name: Run sync
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_SLUG: ${{ github.repository }} # owner/repo
+          GITHUB_TOKEN: ${{ github.token }}
+          ORG: RON-DATADRIVEN
+          PROJECT_NUMBER: '3'
           OUTPUT: docs/modules.json
-          MODULE_LABEL: module
         run: |
+          set -euo pipefail
           ./sync-modules
 
-      - name: Commit & push if changed
-        run: |
-          if ! git diff --quiet -- docs/modules.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/modules.json
-            git commit -m "chore(roadmap): sync modules.json from Issues [skip ci]"
-            git push
-          else
-            echo "No changes to commit."
-          fi
+      - name: Create Pull Request
+        if: success()
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/sync-modules-json
+          title: 'chore: sync modules.json'
+          commit-message: 'chore: sync modules.json'
+          body: 'Actualización automática desde Project EOS 2.0'

--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -1,479 +1,223 @@
 package main
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
-	"fmt"
-	"io"
+	"log"
 	"net/http"
 	"os"
-	"regexp"
-	"strings"
+	"strconv"
 	"time"
+
+	"github.com/shurcooL/githubv4"
 )
 
-type Module struct {
-	ID          string `json:"id"`
-	Nombre      string `json:"nombre"`
-	Descripcion string `json:"descripcion"`
-	Estado      string `json:"estado"`
-	Porcentaje  int    `json:"porcentaje"`
-	Propietario string `json:"propietario"`
-	Inicio      string `json:"inicio"`
-	ETA         string `json:"eta"`
-	Enlaces     []Link `json:"enlaces"`
-}
-
-type Link struct {
-	Label string `json:"label"`
-	URL   string `json:"url"`
-}
-
-/*** ---------------- GraphQL payloads ---------------- ***/
-
-type gqlRequest struct {
-	Query     string                 `json:"query"`
-	Variables map[string]interface{} `json:"variables"`
-}
-
-type gqlResponse struct {
-	Data   *gqlData       `json:"data"`
-	Errors []gqlRespError `json:"errors"`
-}
-
-type gqlRespError struct {
-	Message string `json:"message"`
-}
-
-type gqlData struct {
-	Organization struct {
-		ProjectV2 struct {
-			Items struct {
-				PageInfo struct {
-					HasNextPage bool   `json:"hasNextPage"`
-					EndCursor   string `json:"endCursor"`
-				} `json:"pageInfo"`
-				Nodes []gqlItem `json:"nodes"`
-			} `json:"items"`
-		} `json:"projectV2"`
-	} `json:"organization"`
-}
-
-type gqlItem struct {
-	ID      string `json:"id"`
+type Item struct {
 	Content struct {
-		Typename  string `json:"__typename"`
-		Title     string `json:"title"`
-		URL       string `json:"url"`
-		Body      string `json:"body"`
-		State     string `json:"state"`
-		CreatedAt string `json:"createdAt"`
-		Milestone *struct {
-			DueOn *string `json:"dueOn"`
-		} `json:"milestone"`
-		Assignees struct {
-			Nodes []struct {
-				Login string `json:"login"`
-			} `json:"nodes"`
-		} `json:"assignees"`
-		Labels struct {
-			Nodes []struct {
-				Name string `json:"name"`
-			} `json:"nodes"`
-		} `json:"labels"`
-	} `json:"content"`
-	FieldValues struct {
-		Nodes []gqlFieldValue `json:"nodes"`
-	} `json:"fieldValues"`
+		Issue struct {
+			Number int
+			Title  string
+			URL    githubv4.URI
+		} `graphql:"... on Issue"`
+	} `graphql:"content"`
+
+	Area struct {
+		Typename githubv4.String                `graphql:"__typename"`
+		Single   struct{ Name githubv4.String } `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	} `graphql:"area: fieldValueByName(name:\"Area\")"`
+
+	Status struct {
+		Typename githubv4.String
+		Single   struct{ Name githubv4.String } `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	} `graphql:"status: fieldValueByName(name:\"Status\")"`
+
+	Prioridad struct {
+		Typename githubv4.String
+		Single   struct{ Name githubv4.String } `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	} `graphql:"prioridad: fieldValueByName(name:\"Prioridad\")"`
+
+	Size struct {
+		Typename githubv4.String
+		Single   struct{ Name githubv4.String } `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	} `graphql:"size: fieldValueByName(name:\"Size\")"`
+
+	Iter struct {
+		Typename  githubv4.String
+		Iteration struct {
+			Title     githubv4.String
+			StartDate githubv4.DateTime
+			Duration  int
+		} `graphql:"... on ProjectV2ItemFieldIterationValue"`
+	} `graphql:"iter: fieldValueByName(name:\"Iteration\")"`
+
+	Start struct {
+		Typename githubv4.String
+		Date     githubv4.DateTime `graphql:"date"`
+	} `graphql:"start: fieldValueByName(name:\"Start date\")"`
+
+	ETA struct {
+		Typename githubv4.String
+		Date     githubv4.DateTime `graphql:"date"`
+	} `graphql:"eta: fieldValueByName(name:\"ETA\")"`
 }
 
-type gqlFieldValue struct {
-	Typename string `json:"__typename"`
-	Field    struct {
-		Name string `json:"name"`
-	} `json:"field"`
-	Name   string   `json:"name"`
-	Number *float64 `json:"number"`
-	Date   *string  `json:"date"`
-	Text   *string  `json:"text"`
-	Users  *struct {
-		Nodes []struct {
-			Login string `json:"login"`
-		} `json:"nodes"`
-	} `json:"users"`
+type page struct {
+	Nodes    []Item
+	PageInfo struct {
+		HasNextPage bool
+		EndCursor   githubv4.String
+	}
+}
+
+type Query struct {
+	Org struct {
+		Project struct {
+			Items page `graphql:"items(first: $first, after: $after)"`
+		} `graphql:"projectV2(number: $projectNumber)"`
+	} `graphql:"organization(login: $org)"`
+}
+
+type ModuleOut struct {
+	Issue     int    `json:"issue"`
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	Area      string `json:"area,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Prioridad string `json:"prioridad,omitempty"`
+	Size      string `json:"size,omitempty"`
+	Iteration string `json:"iteration,omitempty"`
+	IterStart string `json:"iterationStart,omitempty"`
+	IterDays  int    `json:"iterationDays,omitempty"`
+	StartDate string `json:"startDate,omitempty"`
+	ETA       string `json:"eta,omitempty"`
+}
+
+func singleName(v struct {
+	Typename githubv4.String
+	Single   struct{ Name githubv4.String }
+}) string {
+	if v.Typename == "ProjectV2ItemFieldSingleSelectValue" {
+		return string(v.Single.Name)
+	}
+	return ""
+}
+
+func toISO(d githubv4.DateTime) string {
+	if d.Time().IsZero() {
+		return ""
+	}
+	return d.Time().Format("2006-01-02")
 }
 
 func main() {
+	log.SetFlags(0)
+
+	org := os.Getenv("ORG")
+	if org == "" {
+		org = "RON-DATADRIVEN"
+	}
+	projectStr := os.Getenv("PROJECT_NUMBER")
+	if projectStr == "" {
+		projectStr = "3"
+	}
+	projectNum, err := strconv.Atoi(projectStr)
+	if err != nil {
+		log.Fatalf("PROJECT_NUMBER inválido: %v", err)
+	}
+	outPath := os.Getenv("OUTPUT")
+	if outPath == "" {
+		outPath = "docs/modules.json"
+	}
+
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		fatal("GITHUB_TOKEN no definido")
+		log.Fatal("GITHUB_TOKEN no está definido")
 	}
 
-	out := getEnv("OUTPUT", "docs/modules.json")
-
-	// ORGANIZACIÓN y NÚMERO DE PROYECTO (Projects v2)
-	org := os.Getenv("PROJECT_ORG")
-	projectNumber := getenvInt("PROJECT_NUMBER", 3)
-	if org == "" {
-		if slug := os.Getenv("REPO_SLUG"); slug != "" && strings.Contains(slug, "/") {
-			org = strings.Split(slug, "/")[0]
-		} else if slug := os.Getenv("GITHUB_REPOSITORY"); slug != "" && strings.Contains(slug, "/") {
-			org = strings.Split(slug, "/")[0]
-		}
+	// HTTP client con auth
+	httpClient := &http.Client{
+		Transport: roundTripperWithToken{token: token},
+		Timeout:   30 * time.Second,
 	}
-	if org == "" {
-		fatal("PROJECT_ORG no definido y no pude inferirlo de REPO_SLUG/GITHUB_REPOSITORY")
-	}
+	cli := githubv4.NewClient(httpClient)
 
-	// Si quieres limitar por label 'module' en el issue contenido:
-	moduleLabel := strings.ToLower(getEnv("MODULE_LABEL", "module"))
-
-	items, err := fetchProjectItems(token, org, projectNumber)
-	if err != nil {
-		fatal(err.Error())
-	}
-
-	modules := make([]Module, 0, len(items))
-	for _, it := range items {
-		// Solo issues (evita PR/Draft como módulos)
-		if strings.ToLower(it.Content.Typename) != "issue" {
-			continue
-		}
-		// Filtra por label 'module' en el issue
-		hasModule := false
-		for _, l := range it.Content.Labels.Nodes {
-			if strings.ToLower(l.Name) == moduleLabel {
-				hasModule = true
-				break
-			}
-		}
-		if !hasModule {
-			continue
-		}
-
-		title := it.Content.Title
-		url := it.Content.URL
-		body := nz(it.Content.Body)
-		created := it.Content.CreatedAt
-
-		// Field map por nombre
-		fv := map[string]gqlFieldValue{}
-		for _, v := range it.FieldValues.Nodes {
-			fv[v.Field.Name] = v
-		}
-
-		// Estado
-		estado := ""
-		if v, ok := fv["Status"]; ok && v.Name != "" {
-			estado = v.Name
-		} else {
-			switch strings.ToLower(it.Content.State) {
-			case "open":
-				estado = "Planificado"
-			case "closed":
-				estado = "Hecho"
-			default:
-				estado = "Planificado"
-			}
-		}
-
-		// Porcentaje (Progreso/Progress/Percent)
-		porc := -1
-		for _, key := range []string{"Progreso", "Progress", "Percent"} {
-			if v, ok := fv[key]; ok {
-				if v.Number != nil {
-					n := *v.Number
-					if n <= 1.0 {
-						porc = int(n*100 + 0.5)
-					} else {
-						porc = int(n + 0.5)
-					}
-					break
-				} else if v.Text != nil {
-					porc = atoiSafe(*v.Text)
-					break
-				}
-			}
-		}
-		if porc < 0 {
-			porc = calcProgressFromBody(body) // fallback a body (checklists / progress:)
-		}
-		porc = clamp(porc, 0, 100)
-
-		// ETA: campo 'ETA' -> milestone.dueOn -> 'eta:' en body
-		eta := ""
-		if v, ok := fv["ETA"]; ok {
-			if v.Date != nil {
-				eta = strings.Split(*v.Date, "T")[0]
-			} else if v.Text != nil {
-				eta = strings.TrimSpace(*v.Text)
-			}
-		}
-		if eta == "" {
-			if it.Content.Milestone != nil && it.Content.Milestone.DueOn != nil {
-				eta = strings.Split(*it.Content.Milestone.DueOn, "T")[0]
-			} else {
-				eta = parseETAFromBody(body)
-			}
-		}
-
-		// Inicio: campo 'Start date' o createdAt
-		inicio := ""
-		if v, ok := fv["Start date"]; ok && v.Date != nil {
-			inicio = strings.Split(*v.Date, "T")[0]
-		} else if created != "" {
-			inicio = strings.Split(created, "T")[0]
-		}
-
-		// Propietario (desde Project User field o directos del issue)
-		prop := joinUsersFromValues(fv, it)
-
-		desc := firstParagraph(clean(body))
-
-		modules = append(modules, Module{
-			ID:          it.ID,
-			Nombre:      title,
-			Descripcion: desc,
-			Estado:      estado,
-			Porcentaje:  porc,
-			Propietario: prop,
-			Inicio:      inicio,
-			ETA:         eta,
-			Enlaces:     []Link{{Label: "Item", URL: url}},
-		})
-	}
-
-	if err := writeJSON(out, modules); err != nil {
-		fatal(err.Error())
-	}
-	fmt.Printf("✔ Generado %s con %d módulos (Project %s#%d)\n", out, len(modules), org, projectNumber)
-}
-
-func fetchProjectItems(token, org string, number int) ([]gqlItem, error) {
-	const q = `
-query ($org: String!, $number: Int!, $first: Int!, $after: String) {
-  organization(login: $org) {
-    projectV2(number: $number) {
-      items(first: $first, after: $after) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          content {
-            __typename
-            ... on Issue {
-              title url body state createdAt
-              milestone { dueOn }
-              assignees(first: 10) { nodes { login } }
-              labels(first: 50) { nodes { name } }
-            }
-            ... on PullRequest { title url body createdAt }
-            ... on DraftIssue { title body }
-          }
-          fieldValues(first: 50) {
-            nodes {
-              __typename
-              field { ... on ProjectV2FieldCommon { name } }
-              ... on ProjectV2ItemFieldSingleSelectValue { name }
-              ... on ProjectV2ItemFieldNumberValue       { number }
-              ... on ProjectV2ItemFieldDateValue         { date }
-              ... on ProjectV2ItemFieldTextValue         { text }
-              ... on ProjectV2ItemFieldUserValue         { users(first: 10) { nodes { login } } }
-            }
-          }
-        }
-      }
-    }
-  }
-}`
-	items := make([]gqlItem, 0, 128)
-	after := ""
-	client := &http.Client{Timeout: 30 * time.Second}
+	first := githubv4.Int(100)
+	var after *githubv4.String
+	var all []ModuleOut
 
 	for {
-		reqBody, _ := json.Marshal(gqlRequest{
-			Query: q,
-			Variables: map[string]interface{}{
-				"org":    org,
-				"number": number,
-				"first":  100,
-				"after":  nullable(after),
-			},
-		})
-		req, _ := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewReader(reqBody))
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("Accept", "application/vnd.github+json")
-		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
+		var q Query
+		vars := map[string]interface{}{
+			"org":           githubv4.String(org),
+			"projectNumber": githubv4.Int(projectNum),
+			"first":         first,
+			"after":         after,
 		}
-		b, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("GraphQL %d: %s", resp.StatusCode, string(b))
+		if err := cli.Query(context.Background(), &q, vars); err != nil {
+			log.Fatalf("GraphQL: %v", err)
 		}
 
-		var gr gqlResponse
-		if err := json.Unmarshal(b, &gr); err != nil {
-			return nil, err
-		}
-		if len(gr.Errors) > 0 {
-			msgs := make([]string, 0, len(gr.Errors))
-			for _, e := range gr.Errors {
-				msgs = append(msgs, e.Message)
+		for _, it := range q.Org.Project.Items.Nodes {
+			// Sólo Issues; ignora PRs/Drafts si aparecieran
+			iss := it.Content.Issue
+			if iss.Number == 0 {
+				continue
 			}
-			return nil, fmt.Errorf("GraphQL errors: %s", strings.Join(msgs, "; "))
+			m := ModuleOut{
+				Issue:     iss.Number,
+				Title:     iss.Title,
+				URL:       iss.URL.String(),
+				Area:      singleName(it.Area),
+				Status:    singleName(it.Status),
+				Prioridad: singleName(it.Prioridad),
+				Size:      singleName(it.Size),
+				StartDate: toISO(it.Start.Date),
+				ETA:       toISO(it.ETA.Date),
+			}
+			if it.Iter.Typename == "ProjectV2ItemFieldIterationValue" {
+				m.Iteration = string(it.Iter.Iteration.Title)
+				m.IterStart = toISO(it.Iter.Iteration.StartDate)
+				m.IterDays = it.Iter.Iteration.Duration
+			}
+			all = append(all, m)
 		}
-		page := gr.Data.Organization.ProjectV2.Items
-		items = append(items, page.Nodes...)
-		if !page.PageInfo.HasNextPage {
+
+		if !q.Org.Project.Items.PageInfo.HasNextPage {
 			break
 		}
-		after = page.PageInfo.EndCursor
+		after = &q.Org.Project.Items.PageInfo.EndCursor
 	}
-	return items, nil
-}
 
-/*** ---------------- helpers ---------------- ***/
-
-func firstParagraph(s string) string {
-	parts := strings.Split(s, "\n\n")
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			if len(p) > 300 {
-				p = p[:300] + "…"
-			}
-			return p
-		}
+	// Crea carpeta si no existe
+	if err := os.MkdirAll(dirOf(outPath), 0o755); err != nil {
+		log.Fatalf("mkdir: %v", err)
 	}
-	return ""
-}
-
-func clean(s string) string {
-	s = strings.ReplaceAll(s, "\r", "")
-	re := regexp.MustCompile(`(?m)^[#>*\-\s` + "`" + `]+`)
-	s = re.ReplaceAllString(s, "")
-	s = strings.ReplaceAll(s, "**", "")
-	s = strings.ReplaceAll(s, "*", "")
-	s = strings.ReplaceAll(s, "`", "")
-	return strings.TrimSpace(s)
-}
-
-func calcProgressFromBody(body string) int {
-	re := regexp.MustCompile(`(?i)(progress|progreso|avance)\s*:\s*(\d{1,3})%?`)
-	if m := re.FindStringSubmatch(body); len(m) == 3 {
-		return atoiSafe(m[2])
-	}
-	reDone := regexp.MustCompile(`(?m)^\s*-\s*\[x\]\s+`)
-	reTodo := regexp.MustCompile(`(?m)^\s*-\s*\[ \]\s+`)
-	done := len(reDone.FindAllStringIndex(body, -1))
-	todo := len(reTodo.FindAllStringIndex(body, -1))
-	if done+todo > 0 {
-		return int(float64(done)/float64(done+todo)*100.0 + 0.5)
-	}
-	return 0
-}
-
-func parseETAFromBody(body string) string {
-	re := regexp.MustCompile(`(?i)eta\s*:\s*(\d{4}-\d{2}-\d{2})`)
-	if m := re.FindStringSubmatch(body); len(m) == 2 {
-		return m[1]
-	}
-	return ""
-}
-
-func joinUsersFromValues(fv map[string]gqlFieldValue, it gqlItem) string {
-	if v, ok := fv["Assignees"]; ok && v.Users != nil && len(v.Users.Nodes) > 0 {
-		logins := make([]string, 0, len(v.Users.Nodes))
-		for _, u := range v.Users.Nodes {
-			logins = append(logins, u.Login)
-		}
-		return strings.Join(logins, ", ")
-	}
-	if len(it.Content.Assignees.Nodes) > 0 {
-		logins := make([]string, 0, len(it.Content.Assignees.Nodes))
-		for _, u := range it.Content.Assignees.Nodes {
-			logins = append(logins, u.Login)
-		}
-		return strings.Join(logins, ", ")
-	}
-	return "—"
-}
-
-func writeJSON(path string, v any) error {
-	b, err := json.MarshalIndent(v, "", "  ")
+	f, err := os.Create(outPath)
 	if err != nil {
-		return err
+		log.Fatalf("crear %s: %v", outPath, err)
 	}
-	if err := os.MkdirAll(dir(path), 0o755); err != nil {
-		return err
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(all); err != nil {
+		log.Fatalf("json: %v", err)
 	}
-	return os.WriteFile(path, b, 0o644)
+	log.Printf("OK: escrito %s con %d elementos", outPath, len(all))
 }
 
-func dir(p string) string {
-	if i := strings.LastIndex(p, "/"); i >= 0 {
-		return p[:i]
+type roundTripperWithToken struct{ token string }
+
+func (rt roundTripperWithToken) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func dirOf(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' || p[i] == '\\' {
+			return p[:i]
+		}
 	}
 	return "."
-}
-
-func clamp(x, a, b int) int {
-	if x < a {
-		return a
-	}
-	if x > b {
-		return b
-	}
-	return x
-}
-
-func atoiSafe(s string) int {
-	n := 0
-	for _, ch := range s {
-		if ch >= '0' && ch <= '9' {
-			n = n*10 + int(ch-'0')
-		}
-	}
-	return n
-}
-
-func nz(s string) string {
-	if s == "" {
-		return ""
-	}
-	return s
-}
-
-func nullable(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
-}
-
-func getenvInt(name string, def int) int {
-	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
-		var n int
-		_, err := fmt.Sscanf(v, "%d", &n)
-		if err == nil {
-			return n
-		}
-	}
-	return def
-}
-
-func getEnv(name, def string) string {
-	if v := os.Getenv(name); v != "" {
-		return v
-	}
-	return def
-}
-
-func fatal(msg string) {
-	fmt.Fprintln(os.Stderr, "ERROR:", msg)
-	os.Exit(1)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module eos-roadmap-tools
 
 go 1.22
 
-require (
-)
-
+require github.com/shurcooL/githubv4 v0.0.0-20240628060444-f4e9a8529af8


### PR DESCRIPTION
## Summary
- replace the existing sync-modules implementation with a GitHub Projects (v2) GraphQL client for Project "EOS 2.0"
- emit docs/modules.json with area, status, priority, size, iteration, start, and ETA fields
- update the sync workflow to set proper permissions, reuse the compiled binary, and open a pull request with changes

## Testing
- go build -o sync-modules ./cmd/sync-modules *(fails locally: module download blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df295ce424832a85ce0d0c34598433