### PR TITLE
fix: Enriquece módulos con tipo de épica

### DIFF
--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -73,10 +73,13 @@ func toISO(d GHFlexDate) string { return d.ISODate() }
 type Item struct {
 	Content struct {
 		Issue struct {
-			Number    int
-			Title     string
-			URL       githubv4.URI
-			Body      string
+			Number int
+			Title  string
+			URL    githubv4.URI
+			Body   string
+			Labels struct {
+				Nodes []labelNode
+			} `graphql:"labels(first: 20)"`
 			Assignees struct {
 				Nodes []assigneeNode
 			} `graphql:"assignees(first: 10)"`
@@ -111,6 +114,12 @@ type Item struct {
 			Duration  int
 		} `graphql:"... on ProjectV2ItemFieldIterationValue"`
 	} `graphql:"iter: fieldValueByName(name:\"Iteration\")"`
+
+	Tipo struct {
+		Typename githubv4.String                 `graphql:"__typename"`
+		Single   struct{ Name githubv4.String }  `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+		Text     struct{ Value githubv4.String } `graphql:"... on ProjectV2ItemFieldTextValue"`
+	} `graphql:"tipo: fieldValueByName(name:\"Tipo\")"`
 
 	Start struct {
 		Typename githubv4.String `graphql:"__typename"`
@@ -148,6 +157,10 @@ type assigneeNode struct {
 	Login string
 }
 
+type labelNode struct {
+	Name string
+}
+
 type ModuleOut struct {
 	ID          string    `json:"id"`
 	Nombre      string    `json:"nombre"`
@@ -158,6 +171,7 @@ type ModuleOut struct {
 	Inicio      string    `json:"inicio,omitempty"`
 	ETA         string    `json:"eta,omitempty"`
 	Enlaces     []LinkOut `json:"enlaces,omitempty"`
+	Tipo        string    `json:"tipo,omitempty"`
 }
 
 type LinkOut struct {
@@ -253,6 +267,68 @@ func buildLinks(url string) []LinkOut {
 	}}
 }
 
+func labelNames(nodes []labelNode) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		name := strings.TrimSpace(n.Name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func collectProjectProps(it Item) map[string]string {
+	props := make(map[string]string)
+	if v := projectValueToString(it.Tipo.Typename, string(it.Tipo.Single.Name), string(it.Tipo.Text.Value)); v != "" {
+		props["Tipo"] = v
+	}
+	if len(props) == 0 {
+		return nil
+	}
+	return props
+}
+
+func projectValueToString(typename githubv4.String, single string, text string) string {
+	switch string(typename) {
+	case "ProjectV2ItemFieldSingleSelectValue":
+		return strings.TrimSpace(single)
+	case "ProjectV2ItemFieldTextValue":
+		return strings.TrimSpace(text)
+	default:
+		return ""
+	}
+}
+
+func detectTipo(title string, labels []string, projectFields map[string]string) string {
+	if projectFields != nil {
+		if v, ok := projectFields["Tipo"]; ok && strings.EqualFold(v, "epic") {
+			return "epic"
+		}
+	}
+	for _, l := range labels {
+		if strings.EqualFold(l, "epic") {
+			return "epic"
+		}
+		upper := strings.ToUpper(strings.TrimSpace(l))
+		if strings.HasPrefix(upper, "ÉPICA") || strings.HasPrefix(upper, "EPICA") {
+			return "epic"
+		}
+	}
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return ""
+	}
+	up := strings.ToUpper(t)
+	if strings.HasPrefix(up, "[ÉPICA]") || strings.HasPrefix(up, "[EPICA]") || strings.HasPrefix(up, "[EPIC]") {
+		return "epic"
+	}
+	return ""
+}
+
 // ---------- Main ----------
 func main() {
 	log.SetFlags(0)
@@ -308,6 +384,8 @@ func main() {
 			}
 			rawStatus := singleName(it.Status.Typename, it.Status.Single.Name)
 			estado, porcentaje := normalizeStatus(rawStatus)
+			labels := labelNames(iss.Labels.Nodes)
+			projectProps := collectProjectProps(it)
 			m := ModuleOut{
 				ID:          strconv.Itoa(iss.Number),
 				Nombre:      iss.Title,
@@ -318,6 +396,7 @@ func main() {
 				Inicio:      toISO(it.Start.DateVal.Date),
 				ETA:         toISO(it.ETA.DateVal.Date),
 				Enlaces:     buildLinks(iss.URL.String()),
+				Tipo:        detectTipo(iss.Title, labels, projectProps),
 			}
 			all = append(all, m)
 		}

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,8 @@
       const filtered = modules.filter(m => {
         const matchStatus = !st || m.estado === st;
         const matchText = !term || (m.nombre + ' ' + (m.descripcion||'')).toLowerCase().includes(term);
-        return matchStatus && matchText;
+        const isEpic = m.tipo === 'epic';
+        return matchStatus && matchText && isEpic;
       });
 
       grid.innerHTML = filtered.map(m => `

--- a/docs/modules.schema.json
+++ b/docs/modules.schema.json
@@ -13,6 +13,11 @@
       "propietario": { "type": "string" },
       "inicio":      { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
       "eta":         { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+      "tipo": {
+        "type": "string",
+        "description": "Clasificación funcional del módulo",
+        "enum": ["epic"]
+      },
       "enlaces": {
         "type": "array",
         "items": {


### PR DESCRIPTION
## Summary
- agrega la recopilación de etiquetas y el campo de proyecto "Tipo" en el sincronizador para derivar `ModuleOut.tipo` como epic
- ajusta el esquema JSON y la UI para consumir el nuevo campo y filtrar únicamente las épicas desde los datos enriquecidos

## Testing
- go build ./cmd/sync-modules

------
https://chatgpt.com/codex/tasks/task_e_68e772ffbfb0832a8342fc5481925c92