### PR TITLE
feat: add create issue backend and modal integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ https://ron-datadriven.github.io/eos-roadmap/
 ## 🔧 New Issues
 https://github.com/RON-DATADRIVEN/eos-roadmap/issues/new/choose
 
+## ☁️ Servicio `create-issue`
+El comando `cmd/create-issue` expone un endpoint HTTP pensado para Cloud Run/Functions. Recibe el template seleccionado desde el modal, crea el issue en GitHub y lo agrega automáticamente al Project EOS 2.0 mediante GraphQL.
+
+### Variables de entorno
+- `GITHUB_TOKEN`: token con permisos `repo` y `project` sobre `RON-DATADRIVEN/eos-roadmap`.
+- `GITHUB_PROJECT_ID`: identificador del ProjectV2 (por ejemplo, el ID de EOS 2.0).
+- `ALLOWED_ORIGIN`: dominio HTTPS permitido para CORS (ej. `https://ron-datadriven.github.io`).
+- `PORT`: opcional, puerto de escucha cuando se ejecuta localmente.
+
+### Despliegue en Cloud Run
+1. Construye la imagen: `gcloud builds submit --tag gcr.io/<project-id>/create-issue cmd/create-issue`.
+2. Despliega: `gcloud run deploy create-issue --image gcr.io/<project-id>/create-issue --region <region> --allow-unauthenticated --set-env-vars ALLOWED_ORIGIN=https://ron-datadriven.github.io,GITHUB_PROJECT_ID=<project-id> --set-secrets GITHUB_TOKEN=github-token:latest`.
+3. Define el secreto `github-token` en Secret Manager (rotación automática recomendada) antes del despliegue.
+
+### Integración con el modal
+- Define la URL del servicio en GitHub Pages usando el atributo `data-issue-service-url` del elemento `<html>` o asignando `window.ISSUE_SERVICE_URL` antes de cargar el script.
+- El modal nunca expone el token; solo envía título y campos normalizados al backend.
+- Los mensajes del modal reflejan el estado (envío, reintentos, advertencias si el Project no se actualiza).
+

--- a/cmd/create-issue/main.go
+++ b/cmd/create-issue/main.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+type fieldType string
+
+const (
+	fieldTypeMarkdown fieldType = "markdown"
+	fieldTypeTextarea fieldType = "textarea"
+	fieldTypeInput    fieldType = "input"
+)
+
+type templateField struct {
+	ID       string
+	Label    string
+	Type     fieldType
+	Required bool
+	Value    string
+}
+
+type issueTemplate struct {
+	ID     string
+	Title  string
+	Labels []string
+	Body   []templateField
+}
+
+var templates = map[string]issueTemplate{
+	"blank": {
+		ID:    "blank",
+		Title: "[ISSUE] Título",
+		Labels: []string{
+			"Status: Ideas",
+			"Tipo :Blank Issue",
+		},
+		Body: []templateField{
+			{
+				ID:    "descripcion",
+				Label: "Descripción",
+				Type:  fieldTypeTextarea,
+				Value: "**Contexto**\n-\n\n**Detalles**\n-\n\n**Criterio de aceptación**\n-",
+			},
+		},
+	},
+	"bug": {
+		ID:    "bug",
+		Title: "fix: <resumen>",
+		Labels: []string{
+			"Tipo: Bug",
+			"Status :En planeación",
+		},
+		Body: []templateField{
+			{ID: "summary", Label: "Resumen", Type: fieldTypeInput, Required: true},
+			{ID: "steps", Label: "Pasos para reproducir", Type: fieldTypeTextarea, Required: true},
+			{ID: "expected", Label: "Comportamiento esperado", Type: fieldTypeTextarea, Required: true},
+			{ID: "actual", Label: "Comportamiento actual", Type: fieldTypeTextarea, Required: true},
+			{ID: "env", Label: "Entorno", Type: fieldTypeTextarea},
+			{ID: "logs", Label: "Logs/evidencia", Type: fieldTypeTextarea},
+		},
+	},
+	"change_request": {
+		ID:    "change_request",
+		Title: "chore: change-request <resumen>",
+		Labels: []string{
+			"Tipo: Change Request",
+			"Status: Ideas",
+		},
+		Body: []templateField{
+			{
+				ID:    "intro",
+				Label: "",
+				Type:  fieldTypeMarkdown,
+				Value: "Describe el cambio propuesto y el impacto (tiempo, costo, riesgo). Será evaluado.",
+			},
+			{ID: "description", Label: "Descripción del cambio", Type: fieldTypeTextarea, Required: true},
+			{ID: "impact", Label: "Impacto (alcance/tiempo/costo/riesgo)", Type: fieldTypeTextarea, Required: true},
+			{ID: "requester", Label: "Solicitante", Type: fieldTypeInput, Required: true},
+		},
+	},
+	"feature": {
+		ID:    "feature",
+		Title: "[FEAT] Título de la feature",
+		Labels: []string{
+			"Tipo: Feature",
+			"Status: Ideas",
+		},
+		Body: []templateField{
+			{ID: "descripcion", Label: "Descripción", Type: fieldTypeTextarea, Required: true},
+			{ID: "criterio", Label: "Criterio de aceptación (resumen)", Type: fieldTypeInput, Required: true},
+		},
+	},
+}
+
+type issueRequest struct {
+	TemplateID string            `json:"templateId"`
+	Title      string            `json:"title"`
+	Fields     map[string]string `json:"fields"`
+}
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type issueResponse struct {
+	IssueURL string    `json:"issueUrl,omitempty"`
+	Error    *apiError `json:"error,omitempty"`
+}
+
+type githubIssueResponse struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	NodeID  string `json:"node_id"`
+}
+
+const (
+	githubRepoOwner = "RON-DATADRIVEN"
+	githubRepoName  = "eos-roadmap"
+	userAgent       = "eos-roadmap-create-issue/1.0"
+)
+
+var (
+	githubToken   = strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	projectID     = strings.TrimSpace(os.Getenv("GITHUB_PROJECT_ID"))
+	allowedOrigin = strings.TrimSpace(os.Getenv("ALLOWED_ORIGIN"))
+)
+
+func main() {
+	if githubToken == "" {
+		log.Fatal("GITHUB_TOKEN no configurado")
+	}
+	if projectID == "" {
+		log.Fatal("GITHUB_PROJECT_ID no configurado")
+	}
+	if allowedOrigin == "" {
+		log.Print("ADVERTENCIA: ALLOWED_ORIGIN vacío, se rechazarán solicitudes con origen")
+	}
+
+	http.HandleFunc("/", handleRequest)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("Escuchando en :%s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatalf("error al iniciar servidor: %v", err)
+	}
+}
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	if !handleCORS(w, r) {
+		return
+	}
+
+	switch r.Method {
+	case http.MethodOptions:
+		w.WriteHeader(http.StatusNoContent)
+		return
+	case http.MethodPost:
+		handlePost(w, r)
+	default:
+		http.Error(w, "método no permitido", http.StatusMethodNotAllowed)
+	}
+}
+
+func handleCORS(w http.ResponseWriter, r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	if allowedOrigin == "" || origin != allowedOrigin {
+		http.Error(w, "origen no permitido", http.StatusForbidden)
+		return false
+	}
+
+	w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+	w.Header().Set("Vary", "Origin")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Max-Age", "3600")
+	return true
+}
+
+func handlePost(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req issueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "JSON inválido")
+		return
+	}
+
+	tmpl, ok := templates[req.TemplateID]
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid_template", "Plantilla no válida")
+		return
+	}
+
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "El título es obligatorio")
+		return
+	}
+
+	fields := map[string]string{}
+	for k, v := range req.Fields {
+		fields[k] = strings.TrimSpace(v)
+	}
+
+	body, err := buildBody(tmpl, fields)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	issue, err := createIssue(ctx, title, tmpl.Labels, body)
+	if err != nil {
+		log.Printf("error al crear issue: %v", err)
+		writeError(w, http.StatusBadGateway, "github_issue_error", "No se pudo crear el issue en GitHub")
+		return
+	}
+
+	err = addToProject(ctx, issue.NodeID)
+	if err != nil {
+		log.Printf("issue #%d creado pero no se pudo agregar al proyecto: %v", issue.Number, err)
+		writeResponse(w, http.StatusOK, issueResponse{
+			IssueURL: issue.HTMLURL,
+			Error: &apiError{
+				Code:    "github_project_error",
+				Message: "Issue creado pero no se pudo agregar al proyecto",
+			},
+		})
+		return
+	}
+
+	writeResponse(w, http.StatusOK, issueResponse{IssueURL: issue.HTMLURL})
+}
+
+func buildBody(tmpl issueTemplate, fields map[string]string) (string, error) {
+	var sections []string
+
+	for _, field := range tmpl.Body {
+		switch field.Type {
+		case fieldTypeMarkdown:
+			if strings.TrimSpace(field.Value) != "" {
+				sections = append(sections, field.Value)
+			}
+		case fieldTypeTextarea, fieldTypeInput:
+			value := strings.TrimSpace(fields[field.ID])
+			if value == "" {
+				if field.Required {
+					return "", fmt.Errorf("El campo '%s' es obligatorio", displayLabel(field))
+				}
+				continue
+			}
+			sections = append(sections, fmt.Sprintf("### %s\n%s", displayLabel(field), value))
+		default:
+			return "", fmt.Errorf("Tipo de campo desconocido: %s", field.Type)
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(sections, "\n\n")), nil
+}
+
+func displayLabel(field templateField) string {
+	if strings.TrimSpace(field.Label) == "" {
+		return field.ID
+	}
+	return field.Label
+}
+
+func createIssue(ctx context.Context, title string, labels []string, body string) (*githubIssueResponse, error) {
+	payload := map[string]any{
+		"title":  title,
+		"body":   body,
+		"labels": labels,
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues", githubRepoOwner, githubRepoName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+githubToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		var apiResp map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			return nil, fmt.Errorf("estado inesperado %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("estado inesperado %d: %v", resp.StatusCode, apiResp)
+	}
+
+	var issue githubIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&issue); err != nil {
+		return nil, err
+	}
+	if issue.NodeID == "" {
+		return nil, errors.New("respuesta sin node_id")
+	}
+	return &issue, nil
+}
+
+func addToProject(ctx context.Context, nodeID string) error {
+	if strings.TrimSpace(nodeID) == "" {
+		return errors.New("node_id vacío")
+	}
+
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
+	httpClient := oauth2.NewClient(ctx, src)
+	gqlClient := githubv4.NewClient(httpClient)
+
+	input := githubv4.AddProjectV2ItemByIdInput{
+		ProjectID: githubv4.ID(projectID),
+		ContentID: githubv4.ID(nodeID),
+	}
+
+	var mutation struct {
+		AddProjectV2ItemByID struct {
+			Item struct {
+				ID githubv4.ID
+			}
+		} `graphql:"addProjectV2ItemById(input: $input)"`
+	}
+
+	return gqlClient.Mutate(ctx, &mutation, input, nil)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeResponse(w, status, issueResponse{Error: &apiError{Code: code, Message: message}})
+}
+
+func writeResponse(w http.ResponseWriter, status int, resp issueResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("error al escribir respuesta: %v", err)
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es" data-issue-service-url="">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -63,11 +63,11 @@
             </div>
             <div id="issueFields" class="field-group"></div>
             <div class="form-actions">
-              <button id="submitIssue" type="submit" class="btn primary">Generar payload</button>
+              <button id="submitIssue" type="submit" class="btn primary">Crear issue</button>
             </div>
           </form>
           <div id="issueFormMessage" class="form-message" role="alert" aria-live="assertive"></div>
-          <pre id="payloadPreview" class="payload-preview hidden" tabindex="0" aria-label="Resultado del payload"></pre>
+          <pre id="payloadPreview" class="payload-preview hidden" tabindex="0" aria-label="Vista previa del cuerpo del issue"></pre>
         </section>
       </div>
     </div>
@@ -90,6 +90,9 @@
     const issueTitle = document.getElementById('issueTitle');
     const issueFormMessage = document.getElementById('issueFormMessage');
     const payloadPreview = document.getElementById('payloadPreview');
+    const submitIssueBtn = document.getElementById('submitIssue');
+
+    const issueServiceURL = (document.documentElement.dataset.issueServiceUrl || window.ISSUE_SERVICE_URL || '').trim();
 
     let modules = [];
     let currentTemplateId = null;
@@ -337,14 +340,33 @@
       });
     }
 
-    function showMessage(message, variant = 'info') {
-      issueFormMessage.textContent = message;
+    function showMessage(message, variant = 'info', link) {
+      issueFormMessage.textContent = '';
       issueFormMessage.className = `form-message ${variant}`;
+
+      if (message) {
+        issueFormMessage.append(document.createTextNode(message));
+      }
+
+      if (link && link.href && link.label) {
+        const anchor = document.createElement('a');
+        anchor.href = link.href;
+        anchor.target = '_blank';
+        anchor.rel = 'noreferrer noopener';
+        anchor.textContent = link.label;
+        anchor.classList.add('form-message-link');
+        issueFormMessage.append(document.createTextNode(' '));
+        issueFormMessage.append(anchor);
+      }
     }
 
     function clearMessage() {
       issueFormMessage.textContent = '';
       issueFormMessage.className = 'form-message';
+    }
+
+    function sleep(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
     }
 
     function getFocusableElements() {
@@ -448,7 +470,9 @@
         return;
       }
 
+      const fieldValues = {};
       const sections = [];
+
       template.body.forEach(field => {
         if (field.type === 'markdown') {
           if (field.value) {
@@ -463,37 +487,95 @@
         }
         const control = wrapper.querySelector('input, textarea');
         const value = (control.value || '').trim();
-        const label = field.label || field.id;
-        sections.push(`### ${label}\n${value}`);
+        if (value || field.required) {
+          fieldValues[field.id] = value;
+        }
+        if (value) {
+          const label = field.label || field.id;
+          sections.push(`### ${label}\n${value}`);
+        }
       });
 
-      const payload = {
+      const previewBody = sections.join('\n\n').trim();
+      payloadPreview.textContent = previewBody || 'Sin contenido';
+      payloadPreview.classList.toggle('hidden', !previewBody);
+
+      if (!issueServiceURL) {
+        showMessage('Servicio de issues no configurado. Contacta al administrador.', 'error');
+        return;
+      }
+
+      const requestPayload = {
+        templateId: template.id,
         title: sanitizedTitle,
-        labels: template.labels,
-        body: sections.join('\n\n').trim()
+        fields: fieldValues
       };
 
-      payloadPreview.textContent = JSON.stringify(payload, null, 2);
-      payloadPreview.classList.remove('hidden');
+      const originalText = submitIssueBtn.textContent;
+      submitIssueBtn.disabled = true;
+      submitIssueBtn.textContent = 'Enviando…';
+      showMessage('Enviando issue…', 'info');
 
-      let copied = false;
-      if (navigator.clipboard && typeof window !== 'undefined' && window.isSecureContext) {
+      const maxAttempts = 2;
+      let responseData = null;
+      let lastError = null;
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
-          await navigator.clipboard.writeText(payloadPreview.textContent);
-          copied = true;
+          const response = await fetch(issueServiceURL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestPayload)
+          });
+
+          const data = await response.json().catch(() => ({}));
+          if (response.ok) {
+            responseData = data;
+            break;
+          }
+
+          lastError = (data && data.error && data.error.message) || `Solicitud rechazada (${response.status})`;
         } catch (error) {
-          copied = false;
+          lastError = error instanceof Error ? error.message : 'Error de red';
+        }
+
+        if (attempt < maxAttempts) {
+          showMessage('Reintentando el envío…', 'warning');
+          await sleep(750);
         }
       }
 
-      if (copied) {
-        showMessage('Payload generado y copiado al portapapeles.', 'success');
-      } else {
-        showMessage('Payload generado. Copia manualmente desde el panel si lo necesitas.', 'warning');
+      submitIssueBtn.disabled = false;
+      submitIssueBtn.textContent = originalText;
+
+      if (!responseData) {
+        showMessage(lastError || 'No se pudo crear el issue.', 'error');
+        return;
       }
 
-      issueForm.reset();
-      populateTemplateFields(template);
+      if (responseData.error && !responseData.issueUrl) {
+        showMessage(responseData.error.message || 'No se pudo crear el issue.', 'error');
+        return;
+      }
+
+      if (!responseData.issueUrl) {
+        showMessage('Respuesta del servicio incompleta.', 'error');
+        return;
+      }
+
+      if (responseData.error) {
+        showMessage(responseData.error.message || 'Issue creado con observaciones.', 'warning', {
+          href: responseData.issueUrl,
+          label: 'Abrir issue'
+        });
+      } else {
+        showMessage('Issue creado correctamente.', 'success', {
+          href: responseData.issueUrl,
+          label: 'Abrir issue'
+        });
+        issueForm.reset();
+        populateTemplateFields(template);
+      }
     }
 
     renderTemplateOptions();

--- a/docs/style.css
+++ b/docs/style.css
@@ -78,6 +78,15 @@ textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .form-message.error { color: var(--red); }
 .form-message.warning { color: var(--yellow); }
 .form-message.info { color: var(--blue); }
+.form-message a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+}
+.form-message a:hover,
+.form-message a:focus {
+  text-decoration: none;
+}
 .payload-preview { background: #090b10; border: 1px solid var(--border); border-radius: 12px; padding: 16px; max-height: 220px; overflow: auto; font-size: 13px; line-height: 1.45; }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add a Cloud Run-friendly create-issue service that posts issues to GitHub and attaches them to the EOS 2.0 project
- connect the modal to the backend with fetch submission, retries, and user-facing status messages while avoiding secret exposure
- document environment variables, deployment steps, and style the modal feedback link

## Testing
- go build ./cmd/...

------
https://chatgpt.com/codex/tasks/task_e_68e9a6619cd8832aa5aaeaa35592f502