### PR TITLE
fix: Normalize create-issue CORS origin handling

### DIFF
--- a/cmd/create-issue/main_test.go
+++ b/cmd/create-issue/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import "testing"
+
+func preserveOriginGlobals(t *testing.T) func() {
+	t.Helper()
+	previousAllowAny := allowAnyOrigin
+	previousAllowed := allowedOrigin
+	previousEntries := allowedOriginEntries
+
+	return func() {
+		allowAnyOrigin = previousAllowAny
+		allowedOrigin = previousAllowed
+		allowedOriginEntries = previousEntries
+	}
+}
+
+func TestNormalizeOrigin(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      string
+		wantError bool
+	}{
+		{name: "https no port", input: "https://ron-datadriven.github.io", want: "https://ron-datadriven.github.io"},
+		{name: "https default port", input: "https://ron-datadriven.github.io:443", want: "https://ron-datadriven.github.io"},
+		{name: "http default port", input: "http://localhost:80", want: "http://localhost"},
+		{name: "custom port", input: "https://example.com:8443", want: "https://example.com:8443"},
+		{name: "whitespace", input: "   https://Example.com  ", want: "https://example.com"},
+		{name: "invalid", input: "not-a-url", wantError: true},
+		{name: "missing host", input: "https://", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeOrigin(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("normalizeOrigin(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitOriginCandidates(t *testing.T) {
+	input := "https://a.example.com, https://b.example.com\nhttps://c.example.com;https://d.example.com"
+	want := []string{
+		"https://a.example.com",
+		"https://b.example.com",
+		"https://c.example.com",
+		"https://d.example.com",
+	}
+
+	got := splitOriginCandidates(input)
+	if len(got) != len(want) {
+		t.Fatalf("unexpected length: got %d want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("element %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSplitOriginCandidatesEmpty(t *testing.T) {
+	got := splitOriginCandidates("   \n\t")
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d elements", len(got))
+	}
+}
+
+func TestConfigureAllowedOriginsDefaultFallback(t *testing.T) {
+	restore := preserveOriginGlobals(t)
+	defer restore()
+
+	allowAnyOrigin = false
+	allowedOrigin = ""
+
+	entries := configureAllowedOrigins("", "https://ron-datadriven.github.io")
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	if entries[0].normalized != "https://ron-datadriven.github.io" {
+		t.Fatalf("unexpected normalized origin: %q", entries[0].normalized)
+	}
+}
+
+func TestConfigureAllowedOriginsWildcard(t *testing.T) {
+	restore := preserveOriginGlobals(t)
+	defer restore()
+
+	allowAnyOrigin = false
+	allowedOrigin = ""
+
+	entries := configureAllowedOrigins("*", "https://fallback.example")
+
+	if !allowAnyOrigin {
+		t.Fatal("allowAnyOrigin should be true")
+	}
+
+	if entries != nil {
+		t.Fatalf("entries should be nil when wildcard is enabled")
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -369,6 +369,23 @@
       return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    function normalizeServiceError(message) {
+      if (!message) {
+        return '';
+      }
+
+      const normalized = message.toLowerCase();
+      if (normalized.includes('failed to fetch') || normalized.includes('networkerror')) {
+        return 'No se pudo contactar al servicio de issues. Verifica la configuración de CORS o la disponibilidad del servicio.';
+      }
+
+      if (normalized.includes('origen no permitido')) {
+        return 'El origen de la petición no está autorizado en el servicio de issues. Revisa la variable ALLOWED_ORIGIN en el backend.';
+      }
+
+      return message;
+    }
+
     function getFocusableElements() {
       return Array.from(issueModal.querySelectorAll('a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'));
     }
@@ -548,13 +565,18 @@
       submitIssueBtn.disabled = false;
       submitIssueBtn.textContent = originalText;
 
+      const friendlyError = normalizeServiceError(lastError);
+
       if (!responseData) {
-        showMessage(lastError || 'No se pudo crear el issue.', 'error');
+        showMessage(friendlyError || 'No se pudo crear el issue.', 'error');
         return;
       }
 
       if (responseData.error && !responseData.issueUrl) {
-        showMessage(responseData.error.message || 'No se pudo crear el issue.', 'error');
+        showMessage(
+          normalizeServiceError(responseData.error.message) || 'No se pudo crear el issue.',
+          'error'
+        );
         return;
       }
 
@@ -564,7 +586,9 @@
       }
 
       if (responseData.error) {
-        showMessage(responseData.error.message || 'Issue creado con observaciones.', 'warning', {
+        const warningMessage =
+          normalizeServiceError(responseData.error.message) || 'Issue creado con observaciones.';
+        showMessage(warningMessage, 'warning', {
           href: responseData.issueUrl,
           label: 'Abrir issue'
         });

--- a/docs/style.css
+++ b/docs/style.css
@@ -60,19 +60,19 @@ textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .template-option.active { border-color: var(--blue); background: rgba(78, 161, 255, .1); }
 .template-name { font-weight: 600; }
 .template-option-description { font-size: 13px; color: var(--muted); }
-.template-form { display: flex; flex-direction: column; gap: 24px; padding-bottom: 16px; }
-.template-meta { display: flex; flex-direction: column; gap: 8px; }
-.template-summary { margin: 8px 0 0; color: var(--muted); font-size: 14px; }
+.template-form { display: flex; flex-direction: column; gap: 28px; padding-bottom: 16px; }
+.template-meta { display: flex; flex-direction: column; gap: 12px; }
+.template-summary { margin: 12px 0 0; color: var(--muted); font-size: 14px; }
 .issue-labels { display: flex; flex-wrap: wrap; gap: 6px; }
 .label-chip { background: rgba(78, 161, 255, .15); color: var(--blue); border: 1px solid rgba(78, 161, 255, .3); padding: 4px 8px; border-radius: 999px; font-size: 12px; }
-.field-group { display: flex; flex-direction: column; gap: 20px; }
-.field { display: flex; flex-direction: column; gap: 6px; }
+.field-group { display: flex; flex-direction: column; gap: 26px; }
+.field { display: flex; flex-direction: column; gap: 8px; }
 .field.markdown { padding: 12px; border: 1px dashed var(--border); border-radius: 10px; background: rgba(21, 24, 33, .6); }
 .field.required label::after { content: ' *'; color: var(--yellow); }
 .field.invalid input,
 .field.invalid textarea { border-color: var(--red); }
-.markdown-hint { margin: 8px 0 0; color: var(--muted); font-size: 14px; white-space: pre-line; }
-.form-actions { display: flex; justify-content: flex-end; margin-top: 24px; }
+.markdown-hint { margin: 12px 0 0; color: var(--muted); font-size: 14px; white-space: pre-line; }
+.form-actions { display: flex; justify-content: flex-end; margin-top: 32px; }
 .form-message { min-height: 20px; font-size: 14px; }
 .form-message.success { color: var(--green); }
 .form-message.error { color: var(--red); }


### PR DESCRIPTION
## Summary
- normalize origin parsing in the create-issue service so default HTTPS ports match configured entries and strip extraneous separators from ALLOWED_ORIGIN
- add helper tests covering origin normalization, candidate parsing, and fallback/wildcard configuration behavior

## Testing
- go test ./cmd/create-issue

------
https://chatgpt.com/codex/tasks/task_e_68e97b4c1788832ab063e995b5e51658