### PR TITLE
fix: corregir etiqueta de plantilla en blanco

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yml
+++ b/.github/ISSUE_TEMPLATE/blank.yml
@@ -1,7 +1,7 @@
 name: 🗿 Issue
 description: Issue libre con estructura mínima
 title: "[ISSUE] Título"
-labels: ["Status: Ideas", Tipo :Blank Issue]
+labels: ["Status: Ideas", "Tipo :Blank Issue"]
 body:
   - type: textarea
     id: descripcion


### PR DESCRIPTION
## Resumen
- encerrar la etiqueta `Tipo :Blank Issue` entre comillas en la plantilla en blanco para asegurar que se trate como cadena literal

## Pruebas
- no se ejecutaron pruebas (cambio de configuración)


------
https://chatgpt.com/codex/tasks/task_e_68e9d7527f90832a8185f1826275f053