### PR TITLE
fix: alinear etiqueta blank con backend

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.yml
+++ b/.github/ISSUE_TEMPLATE/blank.yml
@@ -1,7 +1,7 @@
 name: 🗿 Issue
 description: Issue libre con estructura mínima
 title: "[ISSUE] Título"
-labels: ["Status: Ideas", "Tipo :Blank Issue"]
+labels: ["Status: Ideas", "Tipo: Blank Issue"]
 body:
   - type: textarea
     id: descripcion

--- a/cmd/create-issue/main.go
+++ b/cmd/create-issue/main.go
@@ -46,7 +46,7 @@ var templates = map[string]issueTemplate{
 		Title: "[ISSUE] Título",
 		Labels: []string{
 			"Status: Ideas",
-			"Tipo :Blank Issue",
+			"Tipo: Blank Issue",
 		},
 		Body: []templateField{
 			{
@@ -488,12 +488,7 @@ func displayLabel(field templateField) string {
 }
 
 func createIssue(ctx context.Context, title string, labels []string, body string) (*githubIssueResponse, error) {
-	payload := map[string]any{
-		"title":  title,
-		"body":   body,
-		"labels": labels,
-	}
-	buf, err := json.Marshal(payload)
+	buf, err := buildIssuePayload(title, labels, body)
 	if err != nil {
 		return nil, err
 	}
@@ -534,6 +529,18 @@ func createIssue(ctx context.Context, title string, labels []string, body string
 		return nil, errors.New("respuesta sin node_id")
 	}
 	return &issue, nil
+}
+
+// buildIssuePayload centraliza la construcción del JSON que enviamos a GitHub, de modo
+// que podamos validarlo en pruebas y evitar errores de tipeo o cambios silenciosos en
+// las etiquetas.
+func buildIssuePayload(title string, labels []string, body string) ([]byte, error) {
+	payload := map[string]any{
+		"title":  title,
+		"body":   body,
+		"labels": labels,
+	}
+	return json.Marshal(payload)
 }
 
 func addToProject(ctx context.Context, nodeID string) error {

--- a/cmd/create-issue/main_test.go
+++ b/cmd/create-issue/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -83,6 +84,39 @@ func TestSplitOriginCandidatesEmpty(t *testing.T) {
 	got := splitOriginCandidates("   \n\t")
 	if len(got) != 0 {
 		t.Fatalf("expected empty slice, got %d elements", len(got))
+	}
+}
+
+func TestBlankTemplateSendsExpectedLabels(t *testing.T) {
+	// Definimos las etiquetas esperadas tal como deben viajar hasta GitHub,
+	// evitando discrepancias entre la interfaz y el backend.
+	expectedLabels := []string{"Status: Ideas", "Tipo: Blank Issue"}
+
+	// Validamos primero que la plantilla en memoria coincide con la expectativa.
+	tmpl, ok := templates["blank"]
+	if !ok {
+		t.Fatal("la plantilla 'blank' no existe en el mapa de plantillas")
+	}
+	if !reflect.DeepEqual(tmpl.Labels, expectedLabels) {
+		t.Fatalf("etiquetas configuradas = %v, se esperaba %v", tmpl.Labels, expectedLabels)
+	}
+
+	// Construimos el payload mediante la función compartida con createIssue para
+	// asegurarnos de que las etiquetas correctas llegan sin modificación.
+	payloadBytes, err := buildIssuePayload("[ISSUE] título de prueba", tmpl.Labels, "cuerpo de prueba")
+	if err != nil {
+		t.Fatalf("no se pudo generar el payload: %v", err)
+	}
+
+	var payload struct {
+		Labels []string `json:"labels"`
+	}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		t.Fatalf("no se pudo deserializar el payload: %v", err)
+	}
+
+	if !reflect.DeepEqual(payload.Labels, expectedLabels) {
+		t.Fatalf("etiquetas enviadas = %v, se esperaba %v", payload.Labels, expectedLabels)
 	}
 }
 


### PR DESCRIPTION
## Resumen
- Ajusta la plantilla `blank` para usar la etiqueta `Tipo: Blank Issue` en GitHub y en el backend.
- Refactoriza la creación del payload en `createIssue` para compartir lógica y facilitar pruebas.
- Añade una prueba que valida que la plantilla `blank` incluya ambas etiquetas esperadas en el payload.

## Pruebas
- `GOPROXY=off go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e9dce23554832aa50c28b90f91cc85