### PR TITLE
feat: habilitar beacon de issues en el modal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,16 @@
   </main>
 
   <div id="issueModalOverlay" class="modal-overlay hidden" role="presentation">
-    <div id="issueModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="issueModalTitle" aria-describedby="issueModalDescription" tabindex="-1">
+    <div
+      id="issueModal"
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="issueModalTitle"
+      aria-describedby="issueModalDescription"
+      tabindex="-1"
+      data-issue-beacon-url="https://script.google.com/macros/s/AKfycbxc4mOzsOjx-r0ROx2VNlrP_9g2-02tG7Q1Uc_JVyUgtbr3nzi4f39Kyw5VQ_OcZkADFg/exec"
+    >
       <button id="closeIssueModal" type="button" class="modal-close" aria-label="Cerrar">
         ×
       </button>
@@ -92,7 +101,22 @@
     const payloadPreview = document.getElementById('payloadPreview');
     const submitIssueBtn = document.getElementById('submitIssue');
 
-    const issueServiceURL = (document.documentElement.dataset.issueServiceUrl || window.ISSUE_SERVICE_URL || '').trim();
+    function getBeaconUrl() {
+      // Poka-yoke: Primero revisamos el atributo data-issue-beacon-url del modal para reutilizar la configuración declarativa del HTML.
+      const domValue = (issueModal && issueModal.dataset.issueBeaconUrl ? issueModal.dataset.issueBeaconUrl : '').trim();
+      if (domValue) {
+        return domValue;
+      }
+
+      // Poka-yoke: Si el HTML no trae el valor, usamos la variable global window.ISSUE_BEACON_URL para mantener compatibilidad con configuraciones anteriores.
+      const windowValue = (window.ISSUE_BEACON_URL || '').trim();
+      if (windowValue) {
+        return windowValue;
+      }
+
+      // Poka-yoke: Cuando no se encuentra ningún valor lanzamos un error explícito para evitar que el formulario se envíe sin destino.
+      throw new Error('Servicio de issues no configurado. Contacta al administrador.');
+    }
 
     let modules = [];
     let currentTemplateId = null;
@@ -527,8 +551,13 @@
       payloadPreview.textContent = previewBody || 'Sin contenido';
       payloadPreview.classList.toggle('hidden', !previewBody);
 
-      if (!issueServiceURL) {
-        showMessage('Servicio de issues no configurado. Contacta al administrador.', 'error');
+      let beaconUrl;
+      try {
+        // Poka-yoke: Resolvemos la URL a través de la función centralizada para garantizar que todos los caminos usen la misma validación.
+        beaconUrl = getBeaconUrl();
+      } catch (error) {
+        // Poka-yoke: Si la resolución falla detenemos el flujo y mostramos el mensaje resultante para guiar al usuario.
+        showMessage(error instanceof Error ? error.message : 'Servicio de issues no configurado. Contacta al administrador.', 'error');
         return;
       }
 
@@ -549,7 +578,7 @@
 
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
-          const response = await fetch(issueServiceURL, {
+          const response = await fetch(beaconUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestPayload)


### PR DESCRIPTION
## Resumen
- agrega la URL del beacon de Apps Script al contenedor del modal de issues
- crea la función `getBeaconUrl()` con validaciones y comentarios poka-yoke
- reutiliza el nuevo resolvedor durante el envío y elimina la constante previa

## Pruebas
- no se ejecutaron pruebas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_e_68ebf4faf2b8832a9cdacd7c1c6b52a2