### PR TITLE
fix: garantiza post simple y limpieza del modal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -644,7 +644,7 @@
 
       const serializedPayload = JSON.stringify(payload);
 
-      // Poka-yoke: ejecutamos siempre el formulario oculto para garantizar que la petición se envíe aun si sendBeacon falla.
+      // Poka-yoke: activamos de inmediato el formulario oculto para asegurar un POST simple incluso si el beacon es bloqueado.
       submitViaHiddenForm(beaconUrl, payload);
 
       try {
@@ -654,15 +654,15 @@
         }
       } catch (error) {
         console.error('sendBeacon no pudo ejecutarse.', error);
-      }
-
-      // Poka-yoke: cerramos y limpiamos el modal para que no queden datos sensibles expuestos.
-      closeModal();
-      issueForm.reset();
-      payloadPreview.classList.add('hidden');
-      payloadPreview.textContent = '';
-      if (formState.template) {
-        populateTemplateFields(formState.template);
+      } finally {
+        // Poka-yoke: cerramos y limpiamos el modal para que no queden datos sensibles expuestos aunque el envío falle.
+        closeModal();
+        issueForm.reset();
+        payloadPreview.classList.add('hidden');
+        payloadPreview.textContent = '';
+        if (formState.template) {
+          populateTemplateFields(formState.template);
+        }
       }
     }
 


### PR DESCRIPTION
## Resumen
- ejecuté siempre el envío mediante el formulario oculto justo después de serializar el payload
- mantuve el uso opcional de `navigator.sendBeacon` como intento complementario
- moví el cierre y limpieza del modal a un bloque `finally` para asegurar la restauración del estado

## Pruebas
- No se ejecutaron pruebas (no aplica)

------
https://chatgpt.com/codex/tasks/task_e_68ec708ead1c832abf93c69d0bc4dd2b