### PR TITLE
fix: evita errores al cerrar el modal desde scripts externos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -591,6 +591,11 @@
       }
     }
 
+    // Poka-yoke: exponemos explícitamente la función en window como puente de compatibilidad para integraciones que buscan closeIssueModal.
+    window.closeIssueModal = window.closeIssueModal || closeIssueModal;
+    // Poka-yoke: creamos el alias closeModal en window para evitar errores cuando scripts externos invoquen esa firma histórica.
+    window.closeModal = window.closeModal || closeIssueModal;
+
     async function handleSubmit(event) {
       event.preventDefault();
       clearMessage();


### PR DESCRIPTION
## Resumen
- expone closeIssueModal en window como puente poka-yoke para integraciones legadas
- crea un alias global closeModal que reutiliza closeIssueModal y previene fallos en scripts externos

## Testing
- No se ejecutaron pruebas; cambio de documentación estática

------
https://chatgpt.com/codex/tasks/task_e_68ec709a2bfc832a985aa7bb260e20b1