### PR TITLE
docs: detallar puente poka-yoke para cierre del modal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -591,9 +591,9 @@
       }
     }
 
-    // Poka-yoke: exponemos explícitamente la función en window como puente de compatibilidad para integraciones que buscan closeIssueModal.
+    // Poka-yoke: exponemos explícitamente la función en window como puente poka-yoke de compatibilidad para integraciones que buscan closeIssueModal.
     window.closeIssueModal = window.closeIssueModal || closeIssueModal;
-    // Poka-yoke: creamos el alias closeModal en window para evitar errores cuando scripts externos invoquen esa firma histórica.
+    // Poka-yoke: creamos el alias closeModal en window como puente poka-yoke para evitar errores cuando scripts externos invoquen esa firma histórica.
     window.closeModal = window.closeModal || closeIssueModal;
 
     async function handleSubmit(event) {


### PR DESCRIPTION
## Summary
- detallar en la documentación en línea que las asignaciones globales actúan como un puente poka-yoke
- asegurar que el alias `closeModal` siga apuntando a `closeIssueModal` para integraciones externas

## Testing
- no se requirieron pruebas manuales ni automatizadas para comentarios


------
https://chatgpt.com/codex/tasks/task_e_68ec74cdd47c832aa43ac359f6dab03d