### PR TITLE
feat: permitir bugs en el esquema y documentar tipos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Repositorio para **planificación visible** del proyecto EOS y su **página púb
 2. Commit a `main`. GitHub Pages publica automáticamente.
 3. Comparte el enlace con stakeholders.
 
+### Tipos de módulo permitidos
+- `epic`: iniciativas grandes que agrupan varias tareas o bugs relacionados.
+- `bug`: incidencias detectadas en producción o QA que requieren seguimiento específico.
+
+Mantén estos valores al agregar o actualizar el campo `tipo` en `docs/modules.json` para que el generador de datos y la vista pública permanezcan sincronizados.
+
 ## Plantillas
 - Issues: Feature, Bug, Change Request.
 - Pull Request template + CODEOWNERS.

--- a/docs/modules.schema.json
+++ b/docs/modules.schema.json
@@ -16,7 +16,7 @@
       "tipo": {
         "type": "string",
         "description": "Clasificación funcional del módulo",
-        "enum": ["epic"]
+        "enum": ["epic", "bug"]
       },
       "enlaces": {
         "type": "array",


### PR DESCRIPTION
## Resumen
- permitir el valor `bug` en el enum del esquema de módulos
- documentar en el README los valores soportados para el campo `tipo`

## Pruebas
- python - <<'PY' (validación personalizada de tipos permitidos)


------
https://chatgpt.com/codex/tasks/task_e_68edb6e4f844832a8c6c0c9ac94ea3f2