### PR TITLE
feat: detectar bugs en sincronización

### DIFF
--- a/docs/modules.json
+++ b/docs/modules.json
@@ -1053,7 +1053,8 @@
         "label": "GitHub",
         "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/136"
       }
-    ]
+    ],
+    "tipo": "bug"
   },
   {
     "id": "137",
@@ -1067,7 +1068,8 @@
         "label": "GitHub",
         "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/137"
       }
-    ]
+    ],
+    "tipo": "bug"
   },
   {
     "id": "135",


### PR DESCRIPTION
## Resumen
- actualicé `detectTipo` para reconocer variaciones de bugs tanto en campos del proyecto como en etiquetas, dejando una salida vacía solo cuando no hay coincidencias
- marqué los issues de ejemplo con nombre `fix: BLABLA` como `bug` en `docs/modules.json` para que la vista pueda filtrarlos

## Pruebas
- `go test ./...` *(interrumpido porque la ejecución quedó esperando dependencias externas)*

------
https://chatgpt.com/codex/tasks/task_e_68edb6d2e208832a8c079c2a79901730