### PR TITLE
fix: ocultar bugs cerrados en la vista

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -811,12 +811,18 @@
       // Poka-yoke: leemos el filtro de tipo en minúsculas para comparar sin depender de mayúsculas o valores ausentes.
       const selectedType = typeFilter ? (typeFilter.value || '').toLowerCase() : '';
       const filtered = modules.filter(m => {
-        // Poka-yoke: cuando el selector "Solo bugs" está activo ignoramos cualquier estado elegido,
-        // porque la intención del usuario es revisar todos los bugs sin importar si están planificados o terminados.
+        const normalizedType = (m.tipo || '').toLowerCase();
+        const normalizedStatus = (m.estado || '').toLowerCase();
+        const isBug = normalizedType === 'bug';
+        if (isBug && normalizedStatus === 'hecho') {
+          // Poka-yoke: descartamos bugs cerrados para que nadie interprete que siguen abiertos y evitemos reprocesar tareas resueltas.
+          return false;
+        }
+        // Poka-yoke: cuando el selector "Solo bugs" está activo ignoramos el filtro de estado manual,
+        // porque el objetivo es listar rápidamente los bugs abiertos sin depender de que la persona ajuste otro control.
         const ignoreStatusByBugFilter = selectedType === 'bug';
         const matchStatus = ignoreStatusByBugFilter || !st || m.estado === st;
         const matchText = !term || (m.nombre + ' ' + (m.descripcion||'')).toLowerCase().includes(term);
-        const normalizedType = (m.tipo || '').toLowerCase();
         const matchType = !selectedType || normalizedType === selectedType;
         return matchStatus && matchText && matchType;
       });


### PR DESCRIPTION
## Resumen
- evitar que los bugs cerrados aparezcan en la cuadrícula principal
- documentar el motivo del nuevo filtro con comentarios poka-yoke

## Pruebas
- no se ejecutaron pruebas automatizadas (cambio en lógica de filtrado)


------
https://chatgpt.com/codex/tasks/task_e_68edc09e1714832aa6e01e43ca49acab