### PR TITLE
fix: forzar estado Hecho en issues cerrados

### DIFF
--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -77,6 +77,7 @@ type Item struct {
 			Title  string
 			URL    githubv4.URI
 			Body   string
+			State  githubv4.IssueState // Poka-yoke: capturamos el estado real del issue para evitar inconsistencias con el tablero.
 			Labels struct {
 				Nodes []labelNode
 			} `graphql:"labels(first: 20)"`
@@ -430,6 +431,11 @@ func main() {
 			}
 			rawStatus := singleName(it.Status.Typename, it.Status.Single.Name)
 			estado, porcentaje := normalizeStatus(rawStatus)
+			// Poka-yoke: si GitHub marca el issue como cerrado imponemos "Hecho" para no depender de campos humanos.
+			if iss.State == githubv4.IssueStateClosed {
+				estado = "Hecho"
+				porcentaje = 100
+			}
 			labels := labelNames(iss.Labels.Nodes)
 			projectProps := collectProjectProps(it)
 			m := ModuleOut{


### PR DESCRIPTION
## Resumen
- agrega el campo `state` a la consulta de issues para leer el estado real desde GitHub
- normaliza la salida para forzar `Hecho` y `100%` cuando un issue está cerrado en GitHub, evitando discrepancias con el tablero

## Notas
- no pude regenerar `docs/modules.json` porque la ejecución de `go run ./cmd/sync-modules` requiere un `GITHUB_TOKEN` válido y la llamada queda bloqueada en este entorno


------
https://chatgpt.com/codex/tasks/task_e_68edc8e9dd9c832a8ca86860b61f4bb8