### PR TITLE
fix(automation): use create pull request instead of direct push

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -97,32 +97,17 @@ jobs:
           set -euo pipefail
           ./sync-modules
 
-      - name: Commit & push if changed
-        env:
-          OUTPUT: ${{ env.OUTPUT }}
-          REF_TYPE: ${{ github.ref_type }}   # "branch" o "tag"
-          REF_NAME: ${{ github.ref_name }}   # p.ej. "main"
-        run: |
-          set -euo pipefail
+      - name: Open PR if modules.json changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: ${{ env.OUTPUT }}
+          commit-message: "ci(sync): update modules.json [skip ci]"
+          branch: ci/sync-modules-update
+          delete-branch: true
+          title: "ci(sync): update modules.json"
+          body: |
+            Actualización automática de `docs/modules.json` generada por el workflow `sync-modules`.
 
-          if ! git diff --quiet -- "$OUTPUT"; then
-            git config user.name  "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-            git add "$OUTPUT"
-            git commit -m "ci(sync): update modules.json [skip ci]"
-
-            # Si el run vino de una rama, empuja a esa rama; si fue tag, usa la rama por defecto del remoto.
-            BRANCH="$REF_NAME"
-            if [ "${REF_TYPE}" != "branch" ] || [ -z "$BRANCH" ]; then
-              BRANCH="$(git remote show origin | sed -n 's/  HEAD branch: //p')"
-            fi
-
-            # (Opcional) Rebasar por si la rama avanzó mientras corría el job
-            git fetch origin "$BRANCH"
-            git rebase "origin/$BRANCH"
-
-            git push origin HEAD:"$BRANCH"
-          else
-            echo "No changes to commit."
-          fi
+            Este PR fue creado automáticamente. Si no hay cambios en el archivo, este PR no se abre.
+          labels: automated


### PR DESCRIPTION
## Problema

El workflow `sync-modules.yml` fallaba con GH006 al intentar hacer push directo a `main` protegida:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "test" is expected.
```

## Solución

Se reemplaza el step de `git commit + git push` manual por `peter-evans/create-pull-request@v7`.

**Flujo nuevo:**
1. El workflow genera `docs/modules.json` igual que antes.
2. Si el archivo cambió, la action abre (o actualiza) un PR desde la rama `ci/sync-modules-update` hacia `main`.
3. El check `test` corre sobre ese PR de la forma normal.
4. Un humano (o auto-merge si se configura) mergea el PR.
5. Si el archivo no cambió, no se abre ningún PR.

## Invariantes mantenidos

- Branch protection de `main` intacta.
- Required status check `test` sigue siendo obligatorio.
- No se toca código Go.
- No se usa `--admin` ni bypass de protección.
