### PR TITLE
fix(automation): grant workflow token permissions for sync PR

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: read
+  pull-requests: write
 
 concurrency:
   group: sync-modules-json


### PR DESCRIPTION
Añade `pull-requests: write` al bloque `permissions` del workflow `sync-modules.yml`.

Sin este permiso, `peter-evans/create-pull-request@v7` no puede abrir PRs usando el `GITHUB_TOKEN` nativo del workflow (error de autorización observado en run 24938004914).