### PR TITLE
ci(automation): update modules json

### DIFF
--- a/docs/modules.json
+++ b/docs/modules.json
@@ -2381,5 +2381,19 @@
         "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/267"
       }
     ]
+  },
+  {
+    "id": "277",
+    "nombre": "Migrar Cassandra staging desde servicio instalado en el host hacia Docker Compose",
+    "descripcion": "## Objetivo",
+    "estado": "Planificado",
+    "porcentaje": 0,
+    "propietario": "ArturoPlascenciaRodriguez",
+    "enlaces": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/277"
+      }
+    ]
   }
 ]

--- a/docs/modules.json
+++ b/docs/modules.json
@@ -2385,7 +2385,7 @@
   {
     "id": "277",
     "nombre": "Migrar Cassandra staging desde servicio instalado en el host hacia Docker Compose",
-    "descripcion": "## Objetivo",
+    "descripcion": "## Objetivo Migrar Cassandra en staging desde una instalación directa en el host hacia una configuración gestionada con Docker Compose, para estandarizar el despliegue, simplificar la operación y facilitar su mantenimiento.",
     "estado": "Planificado",
     "porcentaje": 0,
     "propietario": "ArturoPlascenciaRodriguez",


### PR DESCRIPTION
Actualización automática de `docs/modules.json` generada por el workflow `sync-modules`.

Este PR fue creado automáticamente. Si no hay cambios en el archivo, este PR no se abre.