### PR TITLE
feat(roadmap): publish synced roadmap data directly

### DIFF
--- a/.github/protection.json
+++ b/.github/protection.json
@@ -1,18 +1,8 @@
 {
-    "required_status_checks": {
-        "strict": true,
-        "contexts": ["test"]
-    },
+    "required_status_checks": null,
     "enforce_admins": false,
-    "required_pull_request_reviews": {
-        "dismiss_stale_reviews": true,
-        "require_code_owner_reviews": false,
-        "required_approving_review_count": 1,
-        "bypass_pull_request_allowances": {
-            "users": [],
-            "teams": [],
-            "apps": ["github-actions"]
-        }
-    },
-    "restrictions": null
+    "required_pull_request_reviews": null,
+    "restrictions": null,
+    "allow_force_pushes": false,
+    "allow_deletions": false
 }

--- a/.github/protection.json
+++ b/.github/protection.json
@@ -7,7 +7,12 @@
     "required_pull_request_reviews": {
         "dismiss_stale_reviews": true,
         "require_code_owner_reviews": false,
-        "required_approving_review_count": 1
+        "required_approving_review_count": 1,
+        "bypass_pull_request_allowances": {
+            "users": [],
+            "teams": [],
+            "apps": ["github-actions"]
+        }
     },
     "restrictions": null
 }

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -130,4 +130,6 @@ jobs:
           git commit -m "ci(automation): update generated roadmap data"
           # El push usa las credenciales que actions/checkout configuró con el
           # token del checkout porque persist-credentials está habilitado.
+          git fetch origin main
+          git rebase origin/main
           git push origin HEAD:main

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -23,13 +23,23 @@ jobs:
       META_OUTPUT: docs/modules-meta.json
 
     steps:
+      - name: Require direct publish token
+        env:
+          SYNC_PR_TOKEN: ${{ secrets.SYNC_PR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SYNC_PR_TOKEN:-}" ]; then
+            echo "SYNC_PR_TOKEN is required for direct publish to main" >&2
+            exit 1
+          fi
+
       - name: Checkout @ branch main
         uses: actions/checkout@v4
         with:
           ref: main              # evita detached HEAD
           fetch-depth: 0
           persist-credentials: true
-          token: ${{ secrets.SYNC_PR_TOKEN || github.token }}
+          token: ${{ secrets.SYNC_PR_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -39,6 +49,14 @@ jobs:
           cache-dependency-path: |
             go.sum
             **/go.sum
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JSON schema validator
+        run: npm i -g ajv-cli@5 ajv-formats
 
       - name: Sanity repo (HEAD/replace/vendor)
         run: |
@@ -100,11 +118,26 @@ jobs:
           set -euo pipefail
           ./sync-modules
 
+      - name: Validate generated public data before publish
+        run: |
+          set -euo pipefail
+          go test ./...
+          if [ ! -f docs/modules.json ]; then
+            echo "No existe docs/modules.json; se omite validación."
+            exit 0
+          fi
+          ajv validate \
+            -s docs/modules.schema.json \
+            -d docs/modules.json \
+            --spec=draft2020 \
+            -c ajv-formats \
+            --strict=false
+
       # Branch protection debe permitir bypass controlado del requisito de PR
-      # review para el actor del token de checkout (SYNC_PR_TOKEN dedicado o la
-      # app github-actions cuando se usa GITHUB_TOKEN). Si ese bypass no existe,
-      # el push directo a main fallará. No uses un token genérico: este paso solo
-      # stagea y valida docs/modules.json y docs/modules-meta.json.
+      # review para el actor de SYNC_PR_TOKEN. Este token es obligatorio para el
+      # publish directo a main; no hay fallback a GITHUB_TOKEN. Si ese bypass no
+      # existe, el push directo a main fallará. No uses un token genérico: este
+      # paso solo stagea y valida docs/modules.json y docs/modules-meta.json.
       - name: Commit generated public data to main
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   issues: read
-  pull-requests: write
 
 concurrency:
   group: sync-modules-json
@@ -21,6 +20,7 @@ jobs:
       ORG: RON-DATADRIVEN
       PROJECT_NUMBER: "3"
       OUTPUT: docs/modules.json
+      META_OUTPUT: docs/modules-meta.json
 
     steps:
       - name: Checkout @ branch main
@@ -29,6 +29,7 @@ jobs:
           ref: main              # evita detached HEAD
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ secrets.SYNC_PR_TOKEN || github.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -94,21 +95,34 @@ jobs:
           ORG: ${{ env.ORG }}
           PROJECT_NUMBER: ${{ env.PROJECT_NUMBER }}
           OUTPUT: ${{ env.OUTPUT }}
+          META_OUTPUT: ${{ env.META_OUTPUT }}
         run: |
           set -euo pipefail
           ./sync-modules
 
-      - name: Open PR if modules.json changed
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.SYNC_PR_TOKEN }}
-          add-paths: ${{ env.OUTPUT }}
-          commit-message: "ci(automation): update modules json"
-          branch: ci/sync-modules-update
-          delete-branch: true
-          title: "ci(automation): update modules json"
-          body: |
-            Actualización automática de `docs/modules.json` generada por el workflow `sync-modules`.
+      # Branch protection debe permitir que el token de checkout
+      # (SYNC_PR_TOKEN si existe; si no, GITHUB_TOKEN) pueda hacer push directo a
+      # main para los archivos generados docs/modules.json y docs/modules-meta.json.
+      - name: Commit generated public data to main
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-            Este PR fue creado automáticamente. Si no hay cambios en el archivo, este PR no se abre.
-          labels: automated
+          git add -- docs/modules.json docs/modules-meta.json
+
+          staged_files="$(git diff --cached --name-only)"
+          if [ -z "$staged_files" ]; then
+            echo "No generated public data changed."
+            exit 0
+          fi
+
+          unexpected_files="$(printf '%s\n' "$staged_files" | grep -Ev '^(docs/modules\.json|docs/modules-meta\.json)$' || true)"
+          if [ -n "$unexpected_files" ]; then
+            echo "Unexpected staged files:"
+            printf '%s\n' "$unexpected_files"
+            exit 1
+          fi
+
+          git commit -m "ci(automation): update generated roadmap data"
+          git push origin HEAD:main

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -100,9 +100,11 @@ jobs:
           set -euo pipefail
           ./sync-modules
 
-      # Branch protection debe permitir que el token de checkout
-      # (SYNC_PR_TOKEN si existe; si no, GITHUB_TOKEN) pueda hacer push directo a
-      # main para los archivos generados docs/modules.json y docs/modules-meta.json.
+      # Branch protection debe permitir bypass controlado del requisito de PR
+      # review para el actor del token de checkout (SYNC_PR_TOKEN dedicado o la
+      # app github-actions cuando se usa GITHUB_TOKEN). Si ese bypass no existe,
+      # el push directo a main fallará. No uses un token genérico: este paso solo
+      # stagea y valida docs/modules.json y docs/modules-meta.json.
       - name: Commit generated public data to main
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -133,11 +133,10 @@ jobs:
             -c ajv-formats \
             --strict=false
 
-      # Branch protection debe permitir bypass controlado del requisito de PR
-      # review para el actor de SYNC_PR_TOKEN. Este token es obligatorio para el
-      # publish directo a main; no hay fallback a GITHUB_TOKEN. Si ese bypass no
-      # existe, el push directo a main fallará. No uses un token genérico: este
-      # paso solo stagea y valida docs/modules.json y docs/modules-meta.json.
+      # eos-roadmap opera en modelo solo-dev: branch protection no exige PR
+      # reviews ni required status checks para main. Este paso valida antes de
+      # publicar, no usa force push y solo puede commitear los datos generados
+      # docs/modules.json y docs/modules-meta.json.
       - name: Commit generated public data to main
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -109,6 +109,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          allowed_paths_regex='^(docs/modules\.json|docs/modules-meta\.json)$'
+
+          git reset --mixed --quiet
           git add -- docs/modules.json docs/modules-meta.json
 
           staged_files="$(git diff --cached --name-only)"
@@ -117,7 +120,7 @@ jobs:
             exit 0
           fi
 
-          unexpected_files="$(printf '%s\n' "$staged_files" | grep -Ev '^(docs/modules\.json|docs/modules-meta\.json)$' || true)"
+          unexpected_files="$(printf '%s\n' "$staged_files" | grep -Ev "$allowed_paths_regex" || true)"
           if [ -n "$unexpected_files" ]; then
             echo "Unexpected staged files:"
             printf '%s\n' "$unexpected_files"
@@ -125,4 +128,6 @@ jobs:
           fi
 
           git commit -m "ci(automation): update generated roadmap data"
+          # El push usa las credenciales que actions/checkout configuró con el
+          # token del checkout porque persist-credentials está habilitado.
           git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ El JSON generado por el sync debe cumplir `docs/modules.schema.json`.
 
 La vista pública no debe exponer campos internos de aprobación, enlaces de Slack ni identificadores operativos del Project.
 
-El sync no abre PR automático para datos generados. Cuando cambian datos públicos, el workflow hace commit directo a `main` únicamente de `docs/modules.json` y `docs/modules-meta.json`.
-La protección de `main` debe permitir que el actor de `SYNC_PR_TOKEN` haga bypass controlado del requisito de PR review para este flujo. Si branch protection no permite ese bypass, el workflow fallará en `git push origin HEAD:main`. No hay fallback a `GITHUB_TOKEN` para publicar en `main` y no debe usarse un token genérico sin control.
-El workflow ejecuta `go test ./...` y valida `docs/modules.json` contra `docs/modules.schema.json` antes de hacer commit/push directo, porque este flujo no depende de workflows `push` posteriores para validar los datos publicados.
+`eos-roadmap` opera con un modelo solo-dev. El sync no abre PR automático para datos generados: cuando cambian datos públicos, el workflow hace commit directo a `main` únicamente de `docs/modules.json` y `docs/modules-meta.json`.
+La protección de `main` no requiere PR reviews ni required status checks para este repositorio. Como guardrails, la configuración debe seguir bloqueando force push y branch deletion si esas opciones están disponibles.
+`SYNC_PR_TOKEN` sigue siendo obligatorio para publicar en `main`. Debe ser un PAT o token de GitHub App dedicado; no hay fallback a `GITHUB_TOKEN` y no debe usarse un token genérico sin control.
+El workflow valida antes de hacer commit/push directo: ejecuta `go test ./...`, valida `docs/modules.json` contra `docs/modules.schema.json`, y aplica un allowlist exacto para que solo puedan quedar staged `docs/modules.json` y `docs/modules-meta.json`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Secretos requeridos:
 | Secret           | Uso                                                                        |
 | ---------------- | -------------------------------------------------------------------------- |
 | `PROJECTS_TOKEN` | Leer GitHub Projects v2, issues y campos del proyecto.                     |
-| `SYNC_PR_TOKEN`  | Crear o actualizar el PR automático con el `docs/modules.json` regenerado. |
+| `SYNC_PR_TOKEN`  | Opcional. Token de bot dedicado para que el workflow publique datos generados directamente en `main`; si no existe, se usa `GITHUB_TOKEN`. |
 
 El JSON generado por el sync debe cumplir `docs/modules.schema.json`.
 
 La vista pública no debe exponer campos internos de aprobación, enlaces de Slack ni identificadores operativos del Project.
+
+El sync no abre PR automático para datos generados. Cuando cambian datos públicos, el workflow hace commit directo a `main` únicamente de `docs/modules.json` y `docs/modules-meta.json`.
+La protección de `main` debe permitir que el actor del token usado por `.github/workflows/sync-modules.yml` haga bypass controlado del requisito de PR review para este flujo. Si branch protection no permite ese bypass, el workflow fallará en `git push origin HEAD:main`. No debe usarse un token genérico sin control; usa un bot/token dedicado o la app `github-actions` con permisos explícitos de bypass.
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ Secretos requeridos:
 | Secret           | Uso                                                                        |
 | ---------------- | -------------------------------------------------------------------------- |
 | `PROJECTS_TOKEN` | Leer GitHub Projects v2, issues y campos del proyecto.                     |
-| `SYNC_PR_TOKEN`  | Opcional. Token de bot dedicado para que el workflow publique datos generados directamente en `main`; si no existe, se usa `GITHUB_TOKEN`. |
+| `SYNC_PR_TOKEN`  | Obligatorio. PAT o token de GitHub App dedicado para publicar datos generados directamente en `main`. |
 
 El JSON generado por el sync debe cumplir `docs/modules.schema.json`.
 
 La vista pública no debe exponer campos internos de aprobación, enlaces de Slack ni identificadores operativos del Project.
 
 El sync no abre PR automático para datos generados. Cuando cambian datos públicos, el workflow hace commit directo a `main` únicamente de `docs/modules.json` y `docs/modules-meta.json`.
-La protección de `main` debe permitir que el actor del token usado por `.github/workflows/sync-modules.yml` haga bypass controlado del requisito de PR review para este flujo. Si branch protection no permite ese bypass, el workflow fallará en `git push origin HEAD:main`. No debe usarse un token genérico sin control; usa un bot/token dedicado o la app `github-actions` con permisos explícitos de bypass.
+La protección de `main` debe permitir que el actor de `SYNC_PR_TOKEN` haga bypass controlado del requisito de PR review para este flujo. Si branch protection no permite ese bypass, el workflow fallará en `git push origin HEAD:main`. No hay fallback a `GITHUB_TOKEN` para publicar en `main` y no debe usarse un token genérico sin control.
+El workflow ejecuta `go test ./...` y valida `docs/modules.json` contra `docs/modules.schema.json` antes de hacer commit/push directo, porque este flujo no depende de workflows `push` posteriores para validar los datos publicados.
 
 
 

--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -142,10 +142,18 @@ type ModuleOut struct {
 	Tipo        string    `json:"tipo"`
 }
 
+type MetadataOut struct {
+	GeneratedAt string `json:"generatedAt"`
+	Source      string `json:"source"`
+	ItemCount   int    `json:"itemCount"`
+}
+
 type LinkOut struct {
 	Label string `json:"label"`
 	URL   string `json:"url"`
 }
+
+const defaultMetadataSource = "GitHub Project EOS 2.0"
 
 func singleName(typename githubv4.String, name githubv4.String) string {
 	if typename == "ProjectV2ItemFieldSingleSelectValue" {
@@ -366,6 +374,10 @@ func main() {
 	if outPath == "" {
 		outPath = "docs/modules.json"
 	}
+	metaOutPath := os.Getenv("META_OUTPUT")
+	if metaOutPath == "" {
+		metaOutPath = "docs/modules-meta.json"
+	}
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		log.Fatal("GITHUB_TOKEN no está definido")
@@ -439,20 +451,19 @@ func main() {
 		after = &q.Org.Project.Items.PageInfo.EndCursor
 	}
 
-	if err := os.MkdirAll(dirOf(outPath), 0o755); err != nil {
-		log.Fatalf("mkdir: %v", err)
+	if err := writeJSON(outPath, all); err != nil {
+		log.Fatalf("escribir %s: %v", outPath, err)
 	}
-	f, err := os.Create(outPath)
-	if err != nil {
-		log.Fatalf("crear %s: %v", outPath, err)
+
+	metadata := MetadataOut{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Source:      defaultMetadataSource,
+		ItemCount:   len(all),
 	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(all); err != nil {
-		log.Fatalf("json: %v", err)
+	if err := writeJSON(metaOutPath, metadata); err != nil {
+		log.Fatalf("escribir %s: %v", metaOutPath, err)
 	}
-	log.Printf("OK: escrito %s con %d elementos públicos", outPath, len(all))
+	log.Printf("OK: escrito %s y %s con %d elementos públicos", outPath, metaOutPath, len(all))
 }
 
 type roundTripperWithToken struct{ token string }
@@ -470,4 +481,21 @@ func dirOf(p string) string {
 		}
 	}
 	return "."
+}
+
+func writeJSON(path string, value any) error {
+	if err := os.MkdirAll(dirOf(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("crear: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		return fmt.Errorf("json: %w", err)
+	}
+	return nil
 }

--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -451,20 +452,47 @@ func main() {
 		after = &q.Org.Project.Items.PageInfo.EndCursor
 	}
 
-	if err := writeJSON(outPath, all); err != nil {
-		log.Fatalf("escribir %s: %v", outPath, err)
+	changed, err := writeOutputsIfModulesChanged(outPath, metaOutPath, all, time.Now)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !changed {
+		log.Printf("OK: %s sin cambios; no se actualiza %s", outPath, metaOutPath)
+		return
+	}
+	log.Printf("OK: escrito %s y %s con %d elementos públicos", outPath, metaOutPath, len(all))
+}
+
+func writeOutputsIfModulesChanged(outPath string, metaOutPath string, modules []ModuleOut, now func() time.Time) (bool, error) {
+	modulesJSON, err := marshalJSON(modules)
+	if err != nil {
+		return false, fmt.Errorf("preparar %s: %w", outPath, err)
+	}
+	changed, err := fileContentChanged(outPath, modulesJSON)
+	if err != nil {
+		return false, fmt.Errorf("comparar %s: %w", outPath, err)
+	}
+	if !changed {
+		return false, nil
+	}
+	if err := writeFile(outPath, modulesJSON); err != nil {
+		return false, fmt.Errorf("escribir %s: %w", outPath, err)
 	}
 
-	generatedAt := time.Now().UTC().Format(time.RFC3339)
+	generatedAt := now().UTC().Format(time.RFC3339)
 	metadata := MetadataOut{
 		GeneratedAt: generatedAt,
 		Source:      defaultMetadataSource,
-		ItemCount:   len(all),
+		ItemCount:   len(modules),
 	}
-	if err := writeJSON(metaOutPath, metadata); err != nil {
-		log.Fatalf("escribir %s: %v", metaOutPath, err)
+	metadataJSON, err := marshalJSON(metadata)
+	if err != nil {
+		return false, fmt.Errorf("preparar %s: %w", metaOutPath, err)
 	}
-	log.Printf("OK: escrito %s y %s con %d elementos públicos", outPath, metaOutPath, len(all))
+	if err := writeFile(metaOutPath, metadataJSON); err != nil {
+		return false, fmt.Errorf("escribir %s: %w", metaOutPath, err)
+	}
+	return true, nil
 }
 
 type roundTripperWithToken struct{ token string }
@@ -484,19 +512,33 @@ func dirOf(p string) string {
 	return "."
 }
 
-func writeJSON(path string, value any) error {
+func marshalJSON(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func fileContentChanged(path string, content []byte) (bool, error) {
+	current, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return !bytes.Equal(current, content), nil
+}
+
+func writeFile(path string, content []byte) error {
 	if err := os.MkdirAll(dirOf(path), 0o755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("crear: %w", err)
-	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(value); err != nil {
-		return fmt.Errorf("json: %w", err)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("escribir: %w", err)
 	}
 	return nil
 }

--- a/cmd/sync-modules/main.go
+++ b/cmd/sync-modules/main.go
@@ -455,8 +455,9 @@ func main() {
 		log.Fatalf("escribir %s: %v", outPath, err)
 	}
 
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
 	metadata := MetadataOut{
-		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		GeneratedAt: generatedAt,
 		Source:      defaultMetadataSource,
 		ItemCount:   len(all),
 	}

--- a/cmd/sync-modules/main_test.go
+++ b/cmd/sync-modules/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -215,5 +219,151 @@ func TestCalculatePercentage(t *testing.T) {
 				t.Errorf("calculatePercentage(%q, %d) = %d; want %d", tc.body, tc.baseline, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestFileContentChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "modules.json")
+	content := []byte("[\n  {\n    \"id\": \"1\"\n  }\n]\n")
+
+	changed, err := fileContentChanged(path, content)
+	if err != nil {
+		t.Fatalf("fileContentChanged missing file returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("fileContentChanged missing file = false; want true")
+	}
+
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	changed, err = fileContentChanged(path, content)
+	if err != nil {
+		t.Fatalf("fileContentChanged same content returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("fileContentChanged same content = true; want false")
+	}
+
+	changed, err = fileContentChanged(path, []byte("[\n]\n"))
+	if err != nil {
+		t.Fatalf("fileContentChanged different content returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("fileContentChanged different content = false; want true")
+	}
+}
+
+func TestMarshalJSONMatchesGeneratorFormat(t *testing.T) {
+	got, err := marshalJSON([]ModuleOut{{ID: "1", Nombre: "Test", Fase: "Test", Estado: "En atención", Porcentaje: 50, Tipo: "bug"}})
+	if err != nil {
+		t.Fatalf("marshalJSON returned error: %v", err)
+	}
+	want := "[\n  {\n    \"id\": \"1\",\n    \"nombre\": \"Test\",\n    \"descripcion\": \"\",\n    \"fase\": \"Test\",\n    \"estado\": \"En atención\",\n    \"porcentaje\": 50,\n    \"tipo\": \"bug\"\n  }\n]\n"
+	if string(got) != want {
+		t.Fatalf("marshalJSON mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestWriteOutputsIfModulesChangedSkipsMetadataWhenModulesUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	modulesPath := filepath.Join(dir, "modules.json")
+	metaPath := filepath.Join(dir, "modules-meta.json")
+	modules := []ModuleOut{{ID: "1", Nombre: "Test", Fase: "Test", Estado: "En atención", Porcentaje: 50, Tipo: "bug"}}
+	modulesJSON, err := marshalJSON(modules)
+	if err != nil {
+		t.Fatalf("marshalJSON modules: %v", err)
+	}
+	if err := os.WriteFile(modulesPath, modulesJSON, 0o644); err != nil {
+		t.Fatalf("WriteFile modules: %v", err)
+	}
+
+	originalMeta := []byte("{\n  \"generatedAt\": \"2026-01-01T00:00:00Z\",\n  \"source\": \"GitHub Project EOS 2.0\",\n  \"itemCount\": 1\n}\n")
+	if err := os.WriteFile(metaPath, originalMeta, 0o644); err != nil {
+		t.Fatalf("WriteFile metadata: %v", err)
+	}
+	originalTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(metaPath, originalTime, originalTime); err != nil {
+		t.Fatalf("Chtimes metadata: %v", err)
+	}
+
+	changed, err := writeOutputsIfModulesChanged(modulesPath, metaPath, modules, func() time.Time {
+		return time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	})
+	if err != nil {
+		t.Fatalf("writeOutputsIfModulesChanged returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("writeOutputsIfModulesChanged changed = true; want false")
+	}
+
+	gotMeta, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("ReadFile metadata: %v", err)
+	}
+	if string(gotMeta) != string(originalMeta) {
+		t.Fatalf("metadata changed on no-op run:\ngot:\n%s\nwant:\n%s", gotMeta, originalMeta)
+	}
+	gotInfo, err := os.Stat(metaPath)
+	if err != nil {
+		t.Fatalf("Stat metadata: %v", err)
+	}
+	if !gotInfo.ModTime().Equal(originalTime) {
+		t.Fatalf("metadata mtime changed on no-op run: got %s want %s", gotInfo.ModTime(), originalTime)
+	}
+}
+
+func TestWriteOutputsIfModulesChangedWritesMetadataWhenModulesChange(t *testing.T) {
+	dir := t.TempDir()
+	modulesPath := filepath.Join(dir, "modules.json")
+	metaPath := filepath.Join(dir, "modules-meta.json")
+	if err := os.WriteFile(modulesPath, []byte("[]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile modules: %v", err)
+	}
+	if err := os.WriteFile(metaPath, []byte("{\"generatedAt\":\"old\"}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile metadata: %v", err)
+	}
+
+	modules := []ModuleOut{{ID: "1", Nombre: "Test", Fase: "Test", Estado: "En atención", Porcentaje: 50, Tipo: "bug"}}
+	fixedTime := time.Date(2026, 6, 25, 12, 34, 56, 0, time.UTC)
+	changed, err := writeOutputsIfModulesChanged(modulesPath, metaPath, modules, func() time.Time {
+		return fixedTime
+	})
+	if err != nil {
+		t.Fatalf("writeOutputsIfModulesChanged returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("writeOutputsIfModulesChanged changed = false; want true")
+	}
+
+	wantModules, err := marshalJSON(modules)
+	if err != nil {
+		t.Fatalf("marshalJSON modules: %v", err)
+	}
+	gotModules, err := os.ReadFile(modulesPath)
+	if err != nil {
+		t.Fatalf("ReadFile modules: %v", err)
+	}
+	if string(gotModules) != string(wantModules) {
+		t.Fatalf("modules output mismatch:\ngot:\n%s\nwant:\n%s", gotModules, wantModules)
+	}
+
+	var gotMeta MetadataOut
+	gotMetaBytes, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("ReadFile metadata: %v", err)
+	}
+	if err := json.Unmarshal(gotMetaBytes, &gotMeta); err != nil {
+		t.Fatalf("Unmarshal metadata: %v", err)
+	}
+	if gotMeta.GeneratedAt != fixedTime.Format(time.RFC3339) {
+		t.Fatalf("GeneratedAt = %q; want %q", gotMeta.GeneratedAt, fixedTime.Format(time.RFC3339))
+	}
+	if gotMeta.Source != defaultMetadataSource {
+		t.Fatalf("Source = %q; want %q", gotMeta.Source, defaultMetadataSource)
+	}
+	if gotMeta.ItemCount != len(modules) {
+		t.Fatalf("ItemCount = %d; want %d", gotMeta.ItemCount, len(modules))
 	}
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -865,9 +865,9 @@
         if (Number.isNaN(generatedAt.getTime())) {
           throw new Error('metadata generatedAt inválido');
         }
-        return `Última sincronización: ${generatedAt.toLocaleString()}`;
+        return `Última actualización de datos: ${generatedAt.toLocaleString()}`;
       } catch {
-        return 'Última sincronización: no disponible';
+        return 'Última actualización de datos: no disponible';
       }
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -851,7 +851,24 @@
         featureGrid.innerHTML = errorMessage;
         bugGrid.innerHTML = errorMessage;
       }
-      footer.textContent = `Última actualización: ${new Date().toLocaleString()}`;
+      footer.textContent = await syncFooterText();
+    }
+
+    async function syncFooterText() {
+      try {
+        const res = await fetch('modules-meta.json', { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error(`metadata ${res.status}`);
+        }
+        const metadata = await res.json();
+        const generatedAt = new Date(metadata.generatedAt);
+        if (Number.isNaN(generatedAt.getTime())) {
+          throw new Error('metadata generatedAt inválido');
+        }
+        return `Última sincronización: ${generatedAt.toLocaleString()}`;
+      } catch {
+        return 'Última sincronización: no disponible';
+      }
     }
 
     function escapeHTML(value) {

--- a/docs/modules-meta.json
+++ b/docs/modules-meta.json
@@ -1,0 +1,5 @@
+{
+  "generatedAt": "2026-06-25T02:09:54Z",
+  "source": "GitHub Project EOS 2.0",
+  "itemCount": 6
+}

--- a/docs/modules.json
+++ b/docs/modules.json
@@ -1,21 +1,5 @@
 [
   {
-    "id": "288",
-    "nombre": "[FEAT] Prueba",
-    "descripcion": "### Descripción",
-    "fase": "Archivado",
-    "estado": "Archivado",
-    "porcentaje": 100,
-    "propietario": "ArturoPlascenciaRodriguez",
-    "enlaces": [
-      {
-        "label": "GitHub",
-        "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/288"
-      }
-    ],
-    "tipo": "feature"
-  },
-  {
     "id": "164",
     "nombre": "Fallo Agendar",
     "descripcion": "Hola Plascencia! Cómo estás?? Ya tenía buen rato que no nos escribimos!! Oye, sabes que estamos batallando de nuevo con EOS, el mismo error de siempre que al agendar, la hora se marca como “consumida”, pero no continúa su flujo normal :disappointed: no le aparece al experto ni...",
@@ -96,5 +80,21 @@
       }
     ],
     "tipo": "bug"
+  },
+  {
+    "id": "181",
+    "nombre": "Orden en lista de programas iniciando en el ultimo creado por defecto.",
+    "descripcion": "### Descripción Como gestor de programas de emprendimiento quiero ver el utlimo programa creado al inicio de la lista por defecto.",
+    "fase": "Prototipado",
+    "estado": "En prototipo",
+    "porcentaje": 20,
+    "propietario": "ArturoPlascenciaRodriguez",
+    "enlaces": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/RON-DATADRIVEN/eos-roadmap/issues/181"
+      }
+    ],
+    "tipo": "feature"
   }
 ]

--- a/docs/style.css
+++ b/docs/style.css
@@ -31,9 +31,9 @@ select:focus-visible,
 input:focus-visible,
 textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
-.card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 16px; display: flex; flex-direction: column; gap: 10px; }
-.card h3 { margin: 0; font-size: 18px; }
-.badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; border: 1px solid var(--border); }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 16px; display: flex; flex-direction: column; gap: 10px; min-width: 0; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; }
+.card h3 { margin: 0; font-size: 18px; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; }
+.badge { display: inline-block; max-width: 100%; padding: 2px 8px; border-radius: 999px; font-size: 12px; border: 1px solid var(--border); overflow-wrap: anywhere; word-break: break-word; }
 .badge.planificado { background: #272c3f; color: var(--muted); }
 .badge.encurso { background: #2a3a2f; color: var(--green); }
 .badge.hecho { background: #283345; color: var(--blue); }
@@ -51,12 +51,12 @@ textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .section-heading h2 { margin: 0; font-size: 20px; }
 .section-count { color: var(--muted); font-size: 14px; }
 .empty-state { color: var(--muted); border: 1px dashed var(--border); border-radius: 12px; padding: 16px; }
-.desc { color: var(--muted); font-size: 14px; }
-.meta { font-size: 12px; color: var(--muted); display: flex; gap: 14px; flex-wrap: wrap; }
+.desc { color: var(--muted); font-size: 14px; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; }
+.meta { min-width: 0; max-width: 100%; font-size: 12px; color: var(--muted); display: flex; gap: 14px; flex-wrap: wrap; overflow-wrap: anywhere; word-break: break-word; }
 .progress { height: 8px; background: #22283a; border-radius: 999px; overflow: hidden; border: 1px solid var(--border); }
 .progress > div { height: 100%; background: var(--blue); width: 0%; transition: width .4s ease; }
 .footer { color: var(--muted); font-size: 12px; margin-top: 24px; text-align: center; }
-.link { color: var(--blue); text-decoration: none; }
+.link { color: var(--blue); text-decoration: none; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; }
 .link:hover,
 .link:focus-visible { text-decoration: underline; }
 


### PR DESCRIPTION
## Resumen

- Agrega `docs/modules-meta.json` generado por `sync-modules` con `generatedAt`, `source` e `itemCount`.
- Actualiza la página pública para mostrar la hora real de última sincronización desde `modules-meta.json` en lugar de usar `new Date()`.
- Cambia el workflow `sync-modules` para hacer commit directo a `main` solo de `docs/modules.json` y `docs/modules-meta.json`, eliminando `peter-evans/create-pull-request`.
- Ajusta CSS de tarjetas para evitar overflow de títulos, descripciones, badges y links largos.

## Validación

- `go test ./...`
- `git diff --check`
- Confirmado que el workflow ya no referencia `peter-evans/create-pull-request` ni permisos de `pull-requests`.
- Confirmado que el diff no modifica las reglas actuales de publicación de bugs/features.

## Nota operativa

La protección de `main` debe permitir que el token usado por `actions/checkout` (`SYNC_PR_TOKEN` si existe; si no, `GITHUB_TOKEN`) pueda hacer push directo a `main` para `docs/modules.json` y `docs/modules-meta.json`. Si branch protection bloquea ese push, el workflow fallará en el paso `Commit generated public data to main`.